### PR TITLE
fix: don't mark resume as 'failed' for retryable queue errors (#83)

### DIFF
--- a/__tests__/integration/queue/consumer.test.ts
+++ b/__tests__/integration/queue/consumer.test.ts
@@ -643,6 +643,81 @@ describe("Queue Consumer - Main Processing", () => {
     // Should handle parse failure
     await expect(handleQueueMessage(message, env)).rejects.toThrow();
   });
+
+  it("10b. Retryable AI error should NOT set status to 'failed' — Issue #83", async () => {
+    const { handleQueueMessage } = await import("@/lib/queue/consumer");
+
+    const resumeId = crypto.randomUUID();
+    const userId = "user-1";
+    const r2Key = `users/${userId}/123/resume.pdf`;
+
+    createResume({ id: resumeId, status: "queued", totalAttempts: 0 });
+    mockR2Store.set(r2Key, makePdfBuffer());
+
+    // AI returns retryable error (provider timeout) - this triggers the !parseResult.success path
+    mockAiResult = {
+      success: false,
+      error: "AI provider timeout",
+    };
+
+    const updateCalls: Array<{
+      status?: string;
+      lastAttemptError?: string;
+      errorMessage?: string;
+    }> = [];
+
+    const mockDb = {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                status: "queued",
+                parsedContent: null,
+                parsedContentStaged: null,
+                totalAttempts: 0,
+              },
+            ]),
+          }),
+        }),
+      }),
+      update: vi.fn().mockImplementation(() => ({
+        set: vi
+          .fn()
+          .mockImplementation(
+            (values: { status?: string; lastAttemptError?: string; errorMessage?: string }) => {
+              updateCalls.push(values);
+              return {
+                where: vi.fn().mockResolvedValue(undefined),
+              };
+            },
+          ),
+      })),
+    };
+
+    // Use mockReturnValue (not mockReturnValueOnce) because getSessionDbForWebhook is called twice:
+    // once in handleResumeParse and once in handleQueueMessage
+    vi.mocked((await import("@/lib/db/session")).getSessionDbForWebhook).mockReturnValue({
+      db: mockDb as never,
+    });
+
+    const message = createMessage({ resumeId, userId, r2Key });
+    const env = createEnv();
+
+    // Should throw for retry
+    await expect(handleQueueMessage(message, env)).rejects.toThrow("AI provider timeout");
+
+    // Critical: Status should NOT be set to "failed" for retryable errors
+    // The error should only be recorded in lastAttemptError/errorMessage
+    const failedStatusUpdate = updateCalls.find((call) => call.status === "failed");
+    expect(failedStatusUpdate).toBeUndefined();
+
+    // But error should be recorded for debugging
+    const errorUpdate = updateCalls.find((call) =>
+      call.lastAttemptError?.includes("AI provider timeout"),
+    );
+    expect(errorUpdate).toBeDefined();
+  });
 });
 
 // ── Tests: Error Classification ──────────────────────────────────────

--- a/lib/queue/consumer.ts
+++ b/lib/queue/consumer.ts
@@ -3,7 +3,7 @@ import { buildSiteDataUpsert } from "../data/site-data-upsert";
 import { resumes, user } from "../db/schema";
 import { getSessionDbForWebhook } from "../db/session";
 import { getR2Binding, R2 } from "../r2";
-import { classifyQueueError } from "./errors";
+import { classifyQueueError, isRetryableError } from "./errors";
 import { notifyStatusChange, notifyStatusChangeBatch } from "./notify-status";
 import type { QueueMessage, ResumeParseMessage } from "./types";
 
@@ -165,20 +165,19 @@ async function handleResumeParse(message: ResumeParseMessage, env: CloudflareEnv
   if (!parseResult.success) {
     const rawError = parseResult.error || "Parsing failed";
     const userError = getUserFriendlyError(rawError);
+    // Issue #83 Fix: Don't set status to "failed" here - let handleQueueMessage decide
+    // based on whether the error is retryable. Just store error info for later decision.
     await db
       .update(resumes)
       .set({
-        status: "failed",
         errorMessage: userError,
         lastAttemptError: rawError,
       })
       .where(eq(resumes.id, message.resumeId));
-    await notifyStatusChange({
-      resumeId: message.resumeId,
-      status: "failed",
-      error: userError,
-      env,
-    });
+    // Note: We intentionally do NOT call notifyStatusChange here with "failed" status
+    // because we don't want to show false negative to the user for retryable errors.
+    // The worker will decide to retry, and the final "failed" notification will only
+    // be sent after retries are exhausted (handled by DLQ consumer).
     // Throw raw error so classifyQueueError pattern matching still works
     throw new Error(rawError);
   }
@@ -287,12 +286,34 @@ export async function handleQueueMessage(message: QueueMessage, env: CloudflareE
     // Add additional handlers here when new message types are added
     await handleResumeParse(message, env);
   } catch (error) {
-    // Record the error for debugging
-    const classifiedError = classifyQueueError(error);
-    await db
-      .update(resumes)
-      .set({ lastAttemptError: classifiedError.message })
-      .where(eq(resumes.id, message.resumeId));
+    // Issue #83 Fix: Only set status to "failed" for non-retryable errors
+    // For retryable errors, keep status as "processing" so client doesn't see false negative
+    const isRetryable = isRetryableError(error);
+
+    if (!isRetryable) {
+      // Non-retryable error - mark as permanently failed
+      const classifiedError = classifyQueueError(error);
+      await db
+        .update(resumes)
+        .set({
+          status: "failed",
+          lastAttemptError: classifiedError.message,
+        })
+        .where(eq(resumes.id, message.resumeId));
+      await notifyStatusChange({
+        resumeId: message.resumeId,
+        status: "failed",
+        error: classifiedError.message,
+        env,
+      });
+    } else {
+      // Retryable error - just record the error for debugging, don't change status
+      const classifiedError = classifyQueueError(error);
+      await db
+        .update(resumes)
+        .set({ lastAttemptError: classifiedError.message })
+        .where(eq(resumes.id, message.resumeId));
+    }
 
     // Re-throw so the worker can decide whether to retry
     throw error;


### PR DESCRIPTION
Fixes #83

## Summary
When AI parsing fails, the queue consumer was setting \`status: "failed"\` in D1 before throwing, then the worker would retry if the error was retryable. During the window between the failed DB write and the retry pickup, polling clients would see "failed" — a false negative.

## Changes
### lib/queue/consumer.ts
- **handleResumeParse**: Don't set \`status: "failed"\` or notify when AI parsing fails. Just store error info (\`errorMessage\`, \`lastAttemptError\`) and throw. This allows \`handleQueueMessage\` to decide the final status based on error retryability.

- **handleQueueMessage**: Now checks if the error is retryable using \`isRetryableError()\`:
  - **Non-retryable**: Sets \`status: "failed"\`, notifies WebSocket, and sends to DLQ
  - **Retryable**: Only records \`lastAttemptError\` for debugging, keeps status as "processing"

## TDD Evidence
- **Red**: Added test 10b \\ — confirmed failure before fix
- **Green**: Implemented fix — test passes, no \`status: "failed"\` for retryable errors
- **Refactor**: All 1681 tests pass, lint and type-check clean

## Risk Assessment
**Medium** — Queue processing is critical path, but:
- Only affects retryable error handling
- Non-retryable errors still properly marked as failed
- Existing DLQ handling unchanged
- WebSocket notifications for final failure handled by DLQ consumer

## Validation
- \`bun run test\`: 1681 passed (1 new test)
- \`bun run type-check\`: Clean
- \`bun run lint\`: Clean
- \`bun run build\`: Successful

## Auto-merge Readiness
✅ Ready for squash merge when approved. Low architectural risk, focused scope.