### PR TITLE
fix: add hide_from_search toggle to wizard privacy step

### DIFF
--- a/__tests__/unit/components/wizard-privacy-step.test.tsx
+++ b/__tests__/unit/components/wizard-privacy-step.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PrivacyStep } from "@/components/wizard/PrivacyStep";
+import type { ResumeContent } from "@/lib/types/database";
+
+// ============================================================================
+// Mock resume content with contact info
+// ============================================================================
+
+const mockContent: ResumeContent = {
+  contact: {
+    email: "test@example.com",
+    phone: "+1 (555) 123-4567",
+    location: "123 Main St, San Francisco, CA 94102",
+  },
+  full_name: "Test User",
+  headline: "Software Engineer",
+  summary: "Experienced software engineer with expertise in TypeScript and React.",
+  skills: [
+    { category: "Languages", items: ["TypeScript", "JavaScript"] },
+    { category: "Frontend", items: ["React", "Next.js"] },
+  ],
+  experience: [
+    {
+      title: "Developer",
+      company: "Tech Corp",
+      start_date: "2020-01",
+      end_date: "2024-01",
+      description: "Developed web applications using React and TypeScript.",
+      highlights: ["Improved performance by 50%", "Led team of 5 developers"],
+    },
+  ],
+  education: [
+    {
+      degree: "BS Computer Science",
+      institution: "University",
+      graduation_date: "2020",
+    },
+  ],
+};
+
+// ============================================================================
+// PrivacyStep Component Tests
+// ============================================================================
+
+describe("PrivacyStep Component", () => {
+  it("renders with default initial settings", () => {
+    const onContinue = vi.fn();
+
+    render(<PrivacyStep content={mockContent} onContinue={onContinue} />);
+
+    // Check that all toggles are present
+    expect(screen.getByLabelText(/Show Phone Number/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Show Full Address/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Show in Explore Directory/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Hide from Search Engines/i)).toBeInTheDocument();
+  });
+
+  it("renders with custom initial settings including hide_from_search", () => {
+    const onContinue = vi.fn();
+    const initialSettings = {
+      show_phone: true,
+      show_address: true,
+      show_in_directory: false,
+      hide_from_search: true,
+    };
+
+    render(
+      <PrivacyStep
+        content={mockContent}
+        initialSettings={initialSettings}
+        onContinue={onContinue}
+      />,
+    );
+
+    // Check toggles reflect initial settings
+    expect(screen.getByLabelText(/Show Phone Number/i)).toBeChecked();
+    expect(screen.getByLabelText(/Show Full Address/i)).toBeChecked();
+    expect(screen.getByLabelText(/Show in Explore Directory/i)).not.toBeChecked();
+    expect(screen.getByLabelText(/Hide from Search Engines/i)).toBeChecked();
+  });
+
+  it("calls onContinue with all 4 privacy settings including hide_from_search", () => {
+    const onContinue = vi.fn();
+
+    render(<PrivacyStep content={mockContent} onContinue={onContinue} />);
+
+    // Toggle some settings
+    fireEvent.click(screen.getByLabelText(/Show Phone Number/i));
+    fireEvent.click(screen.getByLabelText(/Hide from Search Engines/i));
+
+    // Click continue
+    fireEvent.click(screen.getByText(/Continue/i));
+
+    // Verify onContinue was called with all 4 settings
+    expect(onContinue).toHaveBeenCalledTimes(1);
+    expect(onContinue).toHaveBeenCalledWith({
+      show_phone: true, // toggled from default false
+      show_address: false, // default
+      show_in_directory: true, // default
+      hide_from_search: true, // toggled from default false
+    });
+  });
+
+  it("passes hide_from_search: false by default when no initialSettings provided", () => {
+    const onContinue = vi.fn();
+
+    render(<PrivacyStep content={mockContent} onContinue={onContinue} />);
+
+    // Click continue without changing anything
+    fireEvent.click(screen.getByText(/Continue/i));
+
+    // Verify default includes hide_from_search: false
+    expect(onContinue).toHaveBeenCalledWith({
+      show_phone: false,
+      show_address: false,
+      show_in_directory: true,
+      hide_from_search: false,
+    });
+  });
+
+  it("displays correct preview text for hide_from_search toggle when enabled", () => {
+    const onContinue = vi.fn();
+
+    render(<PrivacyStep content={mockContent} onContinue={onContinue} />);
+
+    // Enable hide from search
+    fireEvent.click(screen.getByLabelText(/Hide from Search Engines/i));
+
+    // Check preview text
+    expect(screen.getByText(/Not indexed by search engines/i)).toBeInTheDocument();
+    expect(screen.getByText(/\(noindex\)/i)).toBeInTheDocument();
+  });
+
+  it("displays correct preview text for hide_from_search toggle when disabled", () => {
+    const onContinue = vi.fn();
+
+    render(<PrivacyStep content={mockContent} onContinue={onContinue} />);
+
+    // Default is disabled, check preview
+    expect(screen.getByText(/Visible in search results/i)).toBeInTheDocument();
+  });
+});

--- a/app/(protected)/wizard/page.tsx
+++ b/app/(protected)/wizard/page.tsx
@@ -73,6 +73,7 @@ interface WizardState {
     show_phone: boolean;
     show_address: boolean;
     show_in_directory: boolean;
+    hide_from_search: boolean;
   };
   themeId: ThemeId;
 }
@@ -120,6 +121,7 @@ export default function WizardPage() {
       show_phone: false,
       show_address: false,
       show_in_directory: true,
+      hide_from_search: false,
     },
     themeId: DEFAULT_THEME,
   });
@@ -420,6 +422,7 @@ export default function WizardPage() {
     show_phone: boolean;
     show_address: boolean;
     show_in_directory: boolean;
+    hide_from_search: boolean;
   }) => {
     setState((prev) => ({
       ...prev,

--- a/components/wizard/PrivacyStep.tsx
+++ b/components/wizard/PrivacyStep.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Eye, EyeOff, Info, MapPin, Phone, Shield, Users } from "lucide-react";
+import { Eye, EyeOff, Info, MapPin, Phone, Search, Shield, Users } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -14,11 +14,13 @@ interface PrivacyStepProps {
     show_phone: boolean;
     show_address: boolean;
     show_in_directory: boolean;
+    hide_from_search: boolean;
   };
   onContinue: (settings: {
     show_phone: boolean;
     show_address: boolean;
     show_in_directory: boolean;
+    hide_from_search: boolean;
   }) => void;
 }
 
@@ -28,18 +30,25 @@ interface PrivacyStepProps {
  */
 export function PrivacyStep({
   content,
-  initialSettings = { show_phone: false, show_address: false, show_in_directory: true },
+  initialSettings = {
+    show_phone: false,
+    show_address: false,
+    show_in_directory: true,
+    hide_from_search: false,
+  },
   onContinue,
 }: PrivacyStepProps) {
   const [showPhone, setShowPhone] = useState(initialSettings.show_phone);
   const [showAddress, setShowAddress] = useState(initialSettings.show_address);
   const [showInDirectory, setShowInDirectory] = useState(initialSettings.show_in_directory);
+  const [hideFromSearch, setHideFromSearch] = useState(initialSettings.hide_from_search);
 
   const handleContinue = () => {
     onContinue({
       show_phone: showPhone,
       show_address: showAddress,
       show_in_directory: showInDirectory,
+      hide_from_search: hideFromSearch,
     });
   };
 
@@ -200,6 +209,47 @@ export function PrivacyStep({
               id="show-in-directory"
               checked={showInDirectory}
               onCheckedChange={setShowInDirectory}
+              className="mt-1"
+            />
+          </div>
+        </Card>
+
+        {/* Search Engine Visibility Toggle */}
+        <Card className="p-6 border-ink/10 shadow-sm">
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex-1">
+              <div className="flex items-center gap-2 mb-2">
+                <Search className="w-5 h-5 text-muted-foreground" />
+                <Label
+                  htmlFor="hide-from-search"
+                  className="text-base font-semibold text-foreground"
+                >
+                  Hide from Search Engines
+                </Label>
+              </div>
+              <p className="text-sm text-muted-foreground mb-3">
+                Prevent search engines like Google from indexing your portfolio
+              </p>
+              <div className="bg-muted border border-ink/15 rounded-lg p-3">
+                <p className="text-xs font-medium text-muted-foreground mb-1">Preview:</p>
+                {hideFromSearch ? (
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <EyeOff className="w-4 h-4 text-coral" />
+                    <span className="font-medium">Not indexed by search engines</span>
+                    <span className="text-xs text-muted-foreground">(noindex)</span>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-2 text-sm text-foreground">
+                    <Eye className="w-4 h-4 text-green-600" />
+                    <span className="font-medium">Visible in search results</span>
+                  </div>
+                )}
+              </div>
+            </div>
+            <Switch
+              id="hide-from-search"
+              checked={hideFromSearch}
+              onCheckedChange={setHideFromSearch}
               className="mt-1"
             />
           </div>


### PR DESCRIPTION
Fixes #85

## Summary
The wizard privacy step was missing the \"hide from search engines\" toggle that exists in the Settings page. This meant users couldn't control search engine indexing during onboarding and had to visit Settings afterward to opt out.

## Changes Made
- **app/(protected)/wizard/page.tsx**: Added \"hide_from_search\" to WizardState interface, initial state, and handlePrivacyContinue type signature
- **components/wizard/PrivacyStep.tsx**: Added \"hide_from_search\" to PrivacyStepProps interface, added Search icon import, added state variable and toggle UI for search engine visibility
- **__tests__/unit/components/wizard-privacy-step.test.tsx**: New test file with 6 tests covering the new toggle functionality

## TDD
- **Red**: Added tests for PrivacyStep with hide_from_search toggle - tests would fail if the toggle wasn't properly implemented
- **Green**: All 62 test files pass (1699 tests total), including 6 new tests for PrivacyStep
- **Refactor**: Applied Biome formatting fixes

## Validation
- \"bun run type-check\" - TypeScript compiles without errors
- \"bun run test\" - All 62 test files pass
- \"bun run lint\" - Biome linting passes

## Risk
**Low** - This is a UI-only change that adds a missing toggle. The API endpoint already supported hide_from_search, and the default value (false - indexable) is the correct behavior for new users.

## Auto-merge readiness
Ready - small scoped change with comprehensive tests.