### PR TITLE
P2: Add WebSocket authentication to prevent cross-user status disclosure

### DIFF
--- a/lib/durable-objects/resume-status.ts
+++ b/lib/durable-objects/resume-status.ts
@@ -37,7 +37,8 @@ export class ClickfolioStatusDO extends DurableObject {
     // WebSocket upgrade — client connecting for live updates
     const upgradeHeader = request.headers.get("Upgrade");
     if (upgradeHeader?.toLowerCase() === "websocket") {
-      return this.handleWebSocketUpgrade();
+      // NEW: Pass request to handleWebSocketUpgrade for auth validation
+      return this.handleWebSocketUpgrade(request);
     }
 
     return new Response("Not found", { status: 404 });
@@ -45,10 +46,17 @@ export class ClickfolioStatusDO extends DurableObject {
 
   /**
    * Accept a WebSocket connection via the Hibernation API.
+   * Requires X-Authenticated-User-Id header (set by worker after auth validation).
    * If there's a cached status, send it immediately so the client
    * doesn't need a separate HTTP fetch.
    */
-  private async handleWebSocketUpgrade(): Promise<Response> {
+  private async handleWebSocketUpgrade(request: Request): Promise<Response> {
+    // NEW: Validate authenticated user header (defense in depth)
+    const userId = request.headers.get("X-Authenticated-User-Id");
+    if (!userId) {
+      return new Response("Unauthorized: Missing authentication", { status: 401 });
+    }
+
     const pair = new WebSocketPair();
     const [client, server] = Object.values(pair);
 

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -4,12 +4,17 @@
  */
 /// <reference path="../lib/cloudflare-env.d.ts" />
 
+import { eq } from "drizzle-orm";
 import handler from "vinext/server/app-router-entry";
+// NEW: Import auth and db session utilities for WebSocket auth
+import { getAuth } from "../lib/auth";
 import { performCleanup } from "../lib/cron/cleanup";
 import { performR2Cleanup } from "../lib/cron/cleanup-r2";
 import { recoverOrphanedResumes } from "../lib/cron/recover-orphaned";
 import { syncDisposableDomains } from "../lib/cron/sync-disposable-domains";
 import { getDb } from "../lib/db";
+import { resumes } from "../lib/db/schema";
+import { getSessionDbForWebhook } from "../lib/db/session";
 import { handleQueueMessage } from "../lib/queue/consumer";
 import { handleDLQMessage } from "../lib/queue/dlq-consumer";
 import { isRetryableError } from "../lib/queue/errors";
@@ -40,6 +45,45 @@ export default {
         return new Response("Missing resume_id query parameter", { status: 400 });
       }
 
+      // NEW: Validate authentication before WebSocket upgrade
+      // Extract session token from Cookie header
+      const cookieHeader = request.headers.get("Cookie") || "";
+      const sessionMatch = cookieHeader.match(/better-auth\.session_token=([^;]+)/);
+      const sessionToken = sessionMatch?.[1];
+
+      if (!sessionToken) {
+        return new Response("Unauthorized: No session token", { status: 401 });
+      }
+
+      // Validate session using Better Auth
+      const auth = await getAuth();
+      // Create a Headers object with the Cookie for auth validation
+      const headersForAuth = new Headers();
+      headersForAuth.set("Cookie", cookieHeader);
+
+      const session = await auth.api.getSession({ headers: headersForAuth });
+
+      if (!session?.user?.id) {
+        return new Response("Unauthorized: Invalid session", { status: 401 });
+      }
+
+      const userId = session.user.id;
+
+      // Verify resume ownership via D1 query
+      const { db } = getSessionDbForWebhook(env.CLICKFOLIO_DB);
+      const resume = await db.query.resumes.findFirst({
+        where: eq(resumes.id, resumeId),
+        columns: { id: true, userId: true },
+      });
+
+      if (!resume) {
+        return new Response("Resume not found", { status: 404 });
+      }
+
+      if (resume.userId !== userId) {
+        return new Response("Forbidden: You don't own this resume", { status: 403 });
+      }
+
       // Route to the Durable Object keyed by resumeId
       if (!env.CLICKFOLIO_STATUS_DO) {
         return new Response("WebSocket not available", { status: 503 });
@@ -48,8 +92,15 @@ export default {
       const doId = env.CLICKFOLIO_STATUS_DO.idFromName(resumeId);
       const stub = env.CLICKFOLIO_STATUS_DO.get(doId);
 
-      // Forward the WebSocket upgrade request to the DO
-      return stub.fetch(request);
+      // NEW: Forward the WebSocket upgrade request to the DO with authenticated user header
+      const modifiedRequest = new Request(request, {
+        headers: {
+          ...Object.fromEntries(request.headers.entries()),
+          "X-Authenticated-User-Id": userId,
+        },
+      });
+
+      return stub.fetch(modifiedRequest);
     }
 
     // All other requests go to vinext handler


### PR DESCRIPTION
## Summary

This PR fixes the security vulnerability described in #90 where the WebSocket endpoint `/ws/resume-status` had zero authentication, allowing any user to subscribe to another user's resume parse status and error messages.

## Security Impact

**Before:** Any user with a valid `resume_id` could connect to `/ws/resume-status?resume_id=X` and receive real-time updates about another user's resume parsing, including:
- Parse progress
- Error messages (potentially exposing sensitive info about document contents)
- Processing status

**After:** Only the resume owner can subscribe to status updates via WebSocket.

## Changes

### worker/index.ts
- Added session validation before WebSocket upgrade
- Extracts `better-auth.session_token` from Cookie header
- Verifies resume ownership via D1 query (resumesTable.userId)
- Returns appropriate HTTP status codes:
  - 401 Unauthorized - missing/invalid session
  - 403 Forbidden - resume belongs to different user
  - 404 Not Found - resume doesn't exist
- Passes authenticated userId to DO via X-Authenticated-User-Id header

### lib/durable-objects/resume-status.ts  
- Added defense-in-depth validation in handleWebSocketUpgrade()
- DO rejects connections without X-Authenticated-User-Id header
- Returns 401 Unauthorized for missing auth header

## Testing

- All 1723 existing tests pass
- TypeScript compilation passes
- Biome linting passes

## Fixes

Closes #90