### PR TITLE
fix: use requireAuthWithUserValidation for stronger auth in 4 routes (#92)

### DIFF
--- a/__tests__/security/idor/profile-routes.test.ts
+++ b/__tests__/security/idor/profile-routes.test.ts
@@ -374,8 +374,12 @@ describe("IDOR - Profile Routes Security", () => {
     });
 
     it("returns 401 for cross-user data access attempt", async () => {
-      mockedAuthMessage.mockResolvedValue({
+      mockedAuth.mockResolvedValue({
         user: null as never,
+        db: null,
+        captureBookmark: null,
+        dbUser: null,
+        env: null,
         error: new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }),
       });
 
@@ -387,6 +391,25 @@ describe("IDOR - Profile Routes Security", () => {
 
     it("prevents profile data access via different endpoint", async () => {
       authedAs("user-a");
+
+      // Mock db to return user data for authenticated user
+      mockLimit.mockResolvedValue([
+        {
+          id: "user-a",
+          name: "Test User",
+          email: "user-a@test.com",
+          image: null,
+          handle: "testuser",
+          headline: null,
+          privacySettings: "{}",
+          onboardingCompleted: true,
+          role: "mid_level",
+          roleSource: null,
+          isAdmin: false,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ]);
 
       // Attempt to access via /api/site-data or other endpoints
       // Should be blocked if not the owner

--- a/app/api/profile/handle/route.ts
+++ b/app/api/profile/handle/route.ts
@@ -1,9 +1,7 @@
-import { env } from "cloudflare:workers";
 import { and, eq, gte, ne, sql } from "drizzle-orm";
-import { requireAuthWithMessage } from "@/lib/auth/middleware";
+import { requireAuthWithUserValidation } from "@/lib/auth/middleware";
 
 import { handleChanges, user } from "@/lib/db/schema";
-import { getSessionDb } from "@/lib/db/session";
 import { handleUpdateSchema } from "@/lib/schemas/profile";
 import {
   createErrorResponse,
@@ -29,13 +27,14 @@ export async function PUT(request: Request) {
       );
     }
 
-    // 2. Authenticate user
-    const authResult = await requireAuthWithMessage("You must be logged in to update your handle");
+    // 2. Authenticate user and validate exists in database
+    const authResult = await requireAuthWithUserValidation(
+      "You must be logged in to update your handle",
+    );
     if (authResult.error) return authResult.error;
-    const { user: authUser } = authResult;
+    const { user: authUser, db, captureBookmark } = authResult;
 
-    // 3. Get database connection
-    const { db, captureBookmark } = await getSessionDb(env.CLICKFOLIO_DB);
+    // 3. Use the db from auth validation (already connected with primary-first consistency)
 
     // 4. Check rate limit (3 handle changes per 24 hours)
     const windowStart = new Date(Date.now() - 24 * 60 * 60 * 1000);

--- a/app/api/profile/me/route.ts
+++ b/app/api/profile/me/route.ts
@@ -1,8 +1,6 @@
-import { env } from "cloudflare:workers";
 import { eq } from "drizzle-orm";
-import { requireAuthWithMessage } from "@/lib/auth/middleware";
+import { requireAuthWithUserValidation } from "@/lib/auth/middleware";
 import { user } from "@/lib/db/schema";
-import { getSessionDb } from "@/lib/db/session";
 import { parsePrivacySettings } from "@/lib/utils/privacy";
 import {
   createErrorResponse,
@@ -16,15 +14,15 @@ import {
  */
 export async function GET() {
   try {
-    // 1. Check authentication via requireAuthWithMessage (read-only route)
-    const { user: authUser, error: authError } = await requireAuthWithMessage(
-      "You must be logged in to access your profile",
-    );
+    // 1. Check authentication and validate user exists in database
+    const {
+      user: authUser,
+      db,
+      error: authError,
+    } = await requireAuthWithUserValidation("You must be logged in to access your profile");
     if (authError) return authError;
 
-    // 2. Get D1 database binding
-    const { db } = await getSessionDb(env.CLICKFOLIO_DB);
-
+    // 2. Use the db from auth validation (already connected with primary-first consistency)
     const userId = authUser.id;
 
     // 3. Fetch user from database

--- a/app/api/resume/latest-status/route.ts
+++ b/app/api/resume/latest-status/route.ts
@@ -1,8 +1,6 @@
-import { env } from "cloudflare:workers";
 import { desc, eq } from "drizzle-orm";
-import { requireAuthWithMessage } from "@/lib/auth/middleware";
+import { requireAuthWithUserValidation } from "@/lib/auth/middleware";
 import { resumes } from "@/lib/db/schema";
-import { getSessionDb } from "@/lib/db/session";
 import {
   createErrorResponse,
   createSuccessResponse,
@@ -15,15 +13,15 @@ import {
  */
 export async function GET() {
   try {
-    // 1. Check authentication via requireAuthWithMessage (read-only route)
-    const { user: authUser, error: authError } = await requireAuthWithMessage(
-      "You must be logged in to check resume status",
-    );
+    // 1. Check authentication and validate user exists in database
+    const {
+      user: authUser,
+      db,
+      error: authError,
+    } = await requireAuthWithUserValidation("You must be logged in to check resume status");
     if (authError) return authError;
 
-    // 2. Get D1 database binding
-    const { db } = await getSessionDb(env.CLICKFOLIO_DB);
-
+    // 2. Use the db from auth validation (already connected with primary-first consistency)
     const userId = authUser.id;
 
     // 3. Fetch the latest resume for the user

--- a/app/api/user/stats/route.ts
+++ b/app/api/user/stats/route.ts
@@ -1,7 +1,5 @@
-import { env } from "cloudflare:workers";
 import { eq } from "drizzle-orm";
-import { requireAuthWithMessage } from "@/lib/auth/middleware";
-import { getDb } from "@/lib/db";
+import { requireAuthWithUserValidation } from "@/lib/auth/middleware";
 import { user } from "@/lib/db/schema";
 
 /**
@@ -12,13 +10,13 @@ import { user } from "@/lib/db/schema";
  */
 export async function GET() {
   try {
-    // Check authentication via requireAuthWithMessage (read-only route)
-    const { user: authUser, error: authError } = await requireAuthWithMessage(
-      "You must be logged in to view stats",
-    );
+    // Check authentication and validate user exists in database
+    const {
+      user: authUser,
+      db,
+      error: authError,
+    } = await requireAuthWithUserValidation("You must be logged in to view stats");
     if (authError) return authError;
-
-    const db = getDb(env.CLICKFOLIO_DB);
 
     const userData = await db.query.user.findFirst({
       where: eq(user.id, authUser.id),


### PR DESCRIPTION
Fixes #92

## Summary
Replaced requireAuthWithMessage with requireAuthWithUserValidation in 4 read-only routes:
- app/api/resume/latest-status/route.ts
- app/api/profile/me/route.ts
- app/api/profile/handle/route.ts
- app/api/user/stats/route.ts

## Security Impact
This adds defense-in-depth validation that the user exists in the D1 database before serving data. Previously, these routes only validated the session token, which could be stale if a user was deleted but their session had not expired.

The stronger auth helper:
1. Validates the Better Auth session (same as before)
2. Additional: Queries D1 to confirm user record exists
3. Returns 404 if user was deleted but session is still valid

All mutation routes already use this stronger auth. This change makes read-only routes consistent with the codebase defense-in-depth pattern.

## Validation
- bun run type-check: Passed
- bun run lint: Passed (5 pre-existing info-level issues)
- bun run test:unit: 883 tests passed
- security/auth/middleware.test.ts: 19 passed, including stale session test
- security/idor/profile-routes.test.ts: 14 passed

## Risk
Low - only affects deleted users with stale sessions. No breaking changes for valid users.