### PR TITLE
Fix audit bugs in sitemap, rate limits, and resume retry

### DIFF
--- a/__tests__/integration/api/resume-operations.test.ts
+++ b/__tests__/integration/api/resume-operations.test.ts
@@ -820,6 +820,53 @@ describe("Resume API Integration Tests (25 tests)", () => {
       expect(body.retry_count).toBe(1);
     });
 
+    it("rolls back retry state when queue publish fails", async () => {
+      const { hasExceededMaxAttempts } = await import("@/lib/config/retry");
+      vi.mocked(hasExceededMaxAttempts).mockReturnValue(false);
+      const { publishResumeParse } = await import("@/lib/queue/resume-parse");
+      vi.mocked(publishResumeParse).mockRejectedValueOnce(new Error("Queue unavailable"));
+
+      authedAs("user-123");
+
+      mockFindFirst.mockResolvedValue({
+        id: "resume-123",
+        userId: "user-123",
+        r2Key: "users/user-123/123/resume.pdf",
+        status: "failed",
+        errorMessage: "PDF parsing error",
+        retryCount: 0,
+        totalAttempts: 2,
+        lastAttemptError: null,
+        fileHash: "abc123hash",
+      });
+
+      const { POST } = await import("@/app/api/resume/retry/route");
+      const request = makeRequest("http://localhost:3000/api/resume/retry", "POST", {
+        resume_id: "resume-123",
+      });
+      const response = await POST(request);
+
+      expect(response.status).toBe(500);
+      expect(mockUpdateSet).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          errorMessage: null,
+          retryCount: 1,
+          status: "queued",
+        }),
+      );
+      expect(mockUpdateSet).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          errorMessage: "PDF parsing error",
+          queuedAt: null,
+          retryCount: 0,
+          status: "failed",
+        }),
+      );
+      expect(mockCaptureBookmark).not.toHaveBeenCalled();
+    });
+
     it("returns 403 when retrying another user's resume (IDOR) (test 13)", async () => {
       authedAs("user-a");
 

--- a/__tests__/unit/lib/sitemap-filter.test.ts
+++ b/__tests__/unit/lib/sitemap-filter.test.ts
@@ -17,6 +17,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mutable reference so each test can swap the rows the mock query chain returns
 let mockSelectRows: unknown[] = [];
+let mockLimitValues: unknown[] = [];
+let mockOffsetValues: unknown[] = [];
 
 /** Build a mock query chain that returns `rows` when awaited */
 function buildQueryChain(rows: unknown[]): Record<string, unknown> {
@@ -29,8 +31,14 @@ function buildQueryChain(rows: unknown[]): Record<string, unknown> {
     from: vi.fn(() => chain()),
     where: vi.fn(() => chain()),
     orderBy: vi.fn(() => chain()),
-    limit: vi.fn(() => chain()),
-    offset: vi.fn(() => chain()),
+    limit: vi.fn((value: unknown) => {
+      mockLimitValues.push(value);
+      return chain();
+    }),
+    offset: vi.fn((value: unknown) => {
+      mockOffsetValues.push(value);
+      return chain();
+    }),
     // biome-ignore lint/suspicious/noThenProperty: mock for Drizzle thenable chain
     then: vi.fn((resolve: (v: unknown) => unknown) => resolve(rows)),
   };
@@ -47,7 +55,13 @@ vi.mock("cloudflare:workers", () => ({
   env: { CLICKFOLIO_DB: {} as D1Database },
 }));
 
-import { generateSitemapEntries, getTotalIndexableUserCount } from "@/lib/sitemap";
+import {
+  generateSitemapEntries,
+  getSitemapShardCount,
+  getTotalIndexableUserCount,
+  STATIC_SITEMAP_ENTRY_COUNT,
+  URLS_PER_SITEMAP,
+} from "@/lib/sitemap";
 
 // ---------------------------------------------------------------------------
 // Tests: generateSitemapEntries
@@ -57,6 +71,8 @@ describe("generateSitemapEntries", () => {
   beforeEach(() => {
     vi.stubEnv("BETTER_AUTH_URL", "https://example.com");
     mockSelectRows = [];
+    mockLimitValues = [];
+    mockOffsetValues = [];
   });
 
   // ── Invalid inputs ──────────────────────────────────────────────
@@ -222,6 +238,20 @@ describe("generateSitemapEntries", () => {
     expect(userEntries).toHaveLength(0);
   });
 
+  it("reserves first shard capacity for static URLs", async () => {
+    await generateSitemapEntries(0);
+
+    expect(mockLimitValues.at(-1)).toBe(URLS_PER_SITEMAP - STATIC_SITEMAP_ENTRY_COUNT);
+    expect(mockOffsetValues.at(-1)).toBe(0);
+  });
+
+  it("offsets later shards after the reduced first-shard user capacity", async () => {
+    await generateSitemapEntries(1);
+
+    expect(mockLimitValues.at(-1)).toBe(URLS_PER_SITEMAP);
+    expect(mockOffsetValues.at(-1)).toBe(URLS_PER_SITEMAP - STATIC_SITEMAP_ENTRY_COUNT);
+  });
+
   // ── Sitemap entry properties ────────────────────────────────────
 
   it("user entries have weekly changeFrequency and 0.8 priority", async () => {
@@ -302,5 +332,14 @@ describe("getTotalIndexableUserCount", () => {
     mockSelectRows = [{ count: 5 }];
     const count = await getTotalIndexableUserCount();
     expect(count).toBe(5);
+  });
+});
+
+describe("getSitemapShardCount", () => {
+  it("accounts for static URLs when deciding whether a second shard is needed", () => {
+    const firstShardUserCapacity = URLS_PER_SITEMAP - STATIC_SITEMAP_ENTRY_COUNT;
+
+    expect(getSitemapShardCount(firstShardUserCapacity)).toBe(1);
+    expect(getSitemapShardCount(firstShardUserCapacity + 1)).toBe(2);
   });
 });

--- a/__tests__/unit/lib/utils/ip-rate-limit.test.ts
+++ b/__tests__/unit/lib/utils/ip-rate-limit.test.ts
@@ -3,6 +3,7 @@
  * Tests for lib/utils/ip-rate-limit.ts
  */
 
+import { eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockDb } from "@/__tests__/setup/mocks/db.mock";
 import {
@@ -24,6 +25,21 @@ vi.mock("@/lib/db", () => ({
 vi.mock("@/lib/utils/environment", () => ({
   isLocalEnvironment: vi.fn().mockReturnValue(false),
 }));
+
+vi.mock("drizzle-orm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("drizzle-orm")>();
+  return {
+    ...actual,
+    and: vi.fn((...conditions: unknown[]) => ({ conditions, type: "and" })),
+    eq: vi.fn((column: unknown, value: unknown) => ({ column, type: "eq", value })),
+    gte: vi.fn((column: unknown, value: unknown) => ({ column, type: "gte", value })),
+    sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+      strings,
+      type: "sql",
+      values,
+    })),
+  };
+});
 
 import { getDb } from "@/lib/db";
 import { isLocalEnvironment } from "@/lib/utils/environment";
@@ -257,17 +273,30 @@ describe("checkIPRateLimit - Production Rate Limiting", () => {
   });
 
   it("records request on success", async () => {
-    const insertMock = vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+    const valuesMock = vi.fn().mockResolvedValue(undefined);
     mockDb.select.mockReturnValue({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockResolvedValue([{ hourly: 0, daily: 0 }]),
       }),
     } as never);
-    mockDb.insert.mockReturnValue(insertMock as never);
+    mockDb.insert.mockReturnValue({ values: valuesMock } as never);
 
     await checkIPRateLimit("192.168.1.1");
 
     expect(mockDb.insert).toHaveBeenCalled();
+    expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({ actionType: "upload" }));
+  });
+
+  it("counts only upload actions toward anonymous upload limits", async () => {
+    mockDb.select.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ hourly: 0, daily: 0 }]),
+      }),
+    } as never);
+
+    await checkIPRateLimit("192.168.1.1");
+
+    expect(vi.mocked(eq).mock.calls.some(([, value]) => value === "upload")).toBe(true);
   });
 
   it("still allows request when record fails (fail open)", async () => {

--- a/app/api/resume/retry/route.ts
+++ b/app/api/resume/retry/route.ts
@@ -66,6 +66,7 @@ export async function POST(request: Request) {
         userId: true,
         r2Key: true,
         status: true,
+        errorMessage: true,
         retryCount: true,
         totalAttempts: true,
         lastAttemptError: true,
@@ -187,10 +188,12 @@ export async function POST(request: Request) {
     }
 
     // Update resume status to queued BEFORE publishing to queue (prevents race condition)
+    const previousRetryCount = resume.retryCount as number;
+    const nextRetryCount = previousRetryCount + 1;
     const updatePayload: Partial<NewResume> = {
       status: "queued",
       errorMessage: null,
-      retryCount: (resume.retryCount as number) + 1,
+      retryCount: nextRetryCount,
       queuedAt: new Date().toISOString(),
     };
 
@@ -205,26 +208,49 @@ export async function POST(request: Request) {
       return createErrorResponse("Failed to update resume status", ERROR_CODES.DATABASE_ERROR, 500);
     }
 
+    const rollbackRetryUpdate = async () => {
+      try {
+        await db
+          .update(resumes)
+          .set({
+            status: "failed",
+            errorMessage: resume.errorMessage,
+            retryCount: previousRetryCount,
+            queuedAt: null,
+          })
+          .where(eq(resumes.id, resume_id));
+      } catch (rollbackError) {
+        console.error("Failed to roll back retry queue state:", rollbackError);
+      }
+    };
+
     // Publish to queue for background processing (after DB update to prevent race)
     const queue = typedEnv.CLICKFOLIO_PARSE_QUEUE;
     if (!queue) {
+      await rollbackRetryUpdate();
       return createErrorResponse("Queue service unavailable", ERROR_CODES.INTERNAL_ERROR, 500);
     }
 
-    await publishResumeParse(queue, {
-      resumeId: resume.id as string,
-      userId,
-      r2Key: resume.r2Key as string,
-      fileHash,
-      attempt: (resume.retryCount as number) + 1,
-    });
+    try {
+      await publishResumeParse(queue, {
+        resumeId: resume.id as string,
+        userId,
+        r2Key: resume.r2Key as string,
+        fileHash,
+        attempt: nextRetryCount,
+      });
+    } catch (queueError) {
+      await rollbackRetryUpdate();
+      console.error("Failed to publish retry parse job:", queueError);
+      return createErrorResponse("Queue service unavailable", ERROR_CODES.INTERNAL_ERROR, 500);
+    }
 
     await captureBookmark();
 
     return createSuccessResponse({
       resume_id: resume.id as string,
       status: "queued",
-      retry_count: (resume.retryCount as number) + 1,
+      retry_count: nextRetryCount,
     });
   } catch (error) {
     console.error("Error retrying resume parsing:", error);

--- a/app/api/sitemap-index/route.ts
+++ b/app/api/sitemap-index/route.ts
@@ -1,8 +1,12 @@
-import { buildSitemapIndexXml, getTotalIndexableUserCount, URLS_PER_SITEMAP } from "@/lib/sitemap";
+import {
+  buildSitemapIndexXml,
+  getSitemapShardCount,
+  getTotalIndexableUserCount,
+} from "@/lib/sitemap";
 
 export async function GET(): Promise<Response> {
   const count = await getTotalIndexableUserCount();
-  const shardCount = Math.max(1, Math.ceil(count / URLS_PER_SITEMAP));
+  const shardCount = getSitemapShardCount(count);
   const xml = buildSitemapIndexXml(shardCount);
 
   return new Response(xml, {

--- a/lib/sitemap.ts
+++ b/lib/sitemap.ts
@@ -19,9 +19,93 @@ const notHiddenFromSearch = or(
 );
 
 export const URLS_PER_SITEMAP = 50000; // Google's limit
+const BASE_STATIC_SITEMAP_ENTRY_COUNT = 5;
+const PROFESSION_PAGE_SLUGS = [
+  "software-engineer",
+  "designer",
+  "marketer",
+  "student",
+  "consultant",
+  "product-manager",
+];
+export const STATIC_SITEMAP_ENTRY_COUNT =
+  BASE_STATIC_SITEMAP_ENTRY_COUNT + PROFESSION_PAGE_SLUGS.length + BLOG_POSTS.length;
 
 export function getSitemapBaseUrl(): string {
   return getPublicSiteUrl();
+}
+
+export function getSitemapShardCount(indexableUserCount: number): number {
+  const safeUserCount = Math.max(0, indexableUserCount);
+  return Math.max(1, Math.ceil((STATIC_SITEMAP_ENTRY_COUNT + safeUserCount) / URLS_PER_SITEMAP));
+}
+
+function getUserShardWindow(id: number): { limit: number; offset: number } {
+  const firstShardUserLimit = Math.max(0, URLS_PER_SITEMAP - STATIC_SITEMAP_ENTRY_COUNT);
+
+  if (id === 0) {
+    return { limit: firstShardUserLimit, offset: 0 };
+  }
+
+  return {
+    limit: URLS_PER_SITEMAP,
+    offset: firstShardUserLimit + (id - 1) * URLS_PER_SITEMAP,
+  };
+}
+
+function buildStaticSitemapEntries(baseUrl: string): MetadataRoute.Sitemap {
+  const entries: MetadataRoute.Sitemap = [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 1.0,
+    },
+    {
+      url: `${baseUrl}/privacy`,
+      lastModified: new Date("2026-02-01"),
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
+      url: `${baseUrl}/terms`,
+      lastModified: new Date("2025-12-01"),
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
+      url: `${baseUrl}/explore`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/blog`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+  ];
+
+  for (const profession of PROFESSION_PAGE_SLUGS) {
+    entries.push({
+      url: `${baseUrl}/for/${profession}`,
+      lastModified: new Date("2026-04-01"),
+      changeFrequency: "monthly",
+      priority: 0.7,
+    });
+  }
+
+  for (const post of BLOG_POSTS) {
+    entries.push({
+      url: `${baseUrl}/blog/${post.slug}`,
+      lastModified: new Date(post.date),
+      changeFrequency: "monthly",
+      priority: 0.7,
+    });
+  }
+
+  return entries;
 }
 
 /**
@@ -37,69 +121,12 @@ export async function generateSitemapEntries(id: number): Promise<MetadataRoute.
   const entries: MetadataRoute.Sitemap = [];
 
   if (id === 0) {
-    entries.push(
-      {
-        url: baseUrl,
-        lastModified: new Date(),
-        changeFrequency: "daily",
-        priority: 1.0,
-      },
-      {
-        url: `${baseUrl}/privacy`,
-        lastModified: new Date("2026-02-01"),
-        changeFrequency: "yearly",
-        priority: 0.3,
-      },
-      {
-        url: `${baseUrl}/terms`,
-        lastModified: new Date("2025-12-01"),
-        changeFrequency: "yearly",
-        priority: 0.3,
-      },
-      {
-        url: `${baseUrl}/explore`,
-        lastModified: new Date(),
-        changeFrequency: "daily",
-        priority: 0.9,
-      },
-      {
-        url: `${baseUrl}/blog`,
-        lastModified: new Date(),
-        changeFrequency: "weekly",
-        priority: 0.8,
-      },
-    );
-
-    const professionPages = [
-      "software-engineer",
-      "designer",
-      "marketer",
-      "student",
-      "consultant",
-      "product-manager",
-    ];
-    for (const profession of professionPages) {
-      entries.push({
-        url: `${baseUrl}/for/${profession}`,
-        lastModified: new Date("2026-04-01"),
-        changeFrequency: "monthly",
-        priority: 0.7,
-      });
-    }
-
-    for (const post of BLOG_POSTS) {
-      entries.push({
-        url: `${baseUrl}/blog/${post.slug}`,
-        lastModified: new Date(post.date),
-        changeFrequency: "monthly",
-        priority: 0.7,
-      });
-    }
+    entries.push(...buildStaticSitemapEntries(baseUrl));
   }
 
   try {
     const db = getDb(env.CLICKFOLIO_DB);
-    const offset = id * URLS_PER_SITEMAP;
+    const { limit, offset } = getUserShardWindow(id);
 
     const users = await db
       .select({
@@ -111,7 +138,7 @@ export async function generateSitemapEntries(id: number): Promise<MetadataRoute.
       .leftJoin(siteData, sql`${siteData.userId} = ${user.id}`)
       .where(and(isNotNull(user.handle), notHiddenFromSearch))
       .orderBy(user.handle)
-      .limit(URLS_PER_SITEMAP)
+      .limit(limit)
       .offset(offset);
 
     for (const entry of users) {

--- a/lib/utils/ip-rate-limit.ts
+++ b/lib/utils/ip-rate-limit.ts
@@ -116,6 +116,7 @@ export async function checkIPRateLimit(ip: string): Promise<IPRateLimitResult> {
       .where(
         and(
           eq(uploadRateLimits.ipHash, ipHash), // Index prefix first
+          eq(uploadRateLimits.actionType, "upload"),
           gte(uploadRateLimits.createdAt, oneDayAgo),
         ),
       );
@@ -151,6 +152,7 @@ export async function checkIPRateLimit(ip: string): Promise<IPRateLimitResult> {
       await db.insert(uploadRateLimits).values({
         id: crypto.randomUUID(),
         ipHash,
+        actionType: "upload",
         createdAt: now.toISOString(),
         expiresAt,
       });


### PR DESCRIPTION
## Summary

- Reserve first sitemap shard capacity for static URLs and count static URLs in the sitemap index
- Keep anonymous upload rate limiting scoped to `actionType = "upload"`
- Roll failed resume retries back if queue publishing cannot complete

## Issues

Closes #108
Closes #109
Closes #110

## Verification

- `bun run type-check`
- `bun run lint`
- `bun run test`
- `bun run build`
- `bunx knip`
- `bunx biome ci .`