### PR TITLE
[codex] Raise test coverage gate to 80%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: latest
 
@@ -37,10 +39,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: latest
 
@@ -49,7 +53,7 @@ jobs:
         run: echo "dir=$(bun pm cache)" >> $GITHUB_OUTPUT
 
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ${{ steps.bun-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
@@ -68,10 +72,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: latest
 
@@ -80,7 +86,7 @@ jobs:
         run: echo "dir=$(bun pm cache)" >> $GITHUB_OUTPUT
 
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ${{ steps.bun-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
@@ -94,7 +100,7 @@ jobs:
         run: bun run test:unit -- --coverage
 
       - name: Upload unit coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: always()
         with:
           name: unit-coverage-report
@@ -106,10 +112,12 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: latest
 
@@ -118,7 +126,7 @@ jobs:
         run: echo "dir=$(bun pm cache)" >> $GITHUB_OUTPUT
 
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ${{ steps.bun-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
@@ -132,7 +140,7 @@ jobs:
         run: bun run test:integration -- --coverage
 
       - name: Upload integration coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: always()
         with:
           name: integration-coverage-report
@@ -144,10 +152,12 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: latest
 
@@ -156,7 +166,7 @@ jobs:
         run: echo "dir=$(bun pm cache)" >> $GITHUB_OUTPUT
 
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ${{ steps.bun-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
@@ -170,7 +180,7 @@ jobs:
         run: bun run test:security -- --coverage
 
       - name: Upload security coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: always()
         with:
           name: security-coverage-report
@@ -183,28 +193,30 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Download unit coverage
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: unit-coverage-report
           path: coverage/unit/
 
       - name: Download integration coverage
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: integration-coverage-report
           path: coverage/integration/
 
       - name: Download security coverage
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: security-coverage-report
           path: coverage/security/
 
       - name: Comment coverage on PR
-        uses: romeovs/lcov-reporter-action@v0.4.0
+        uses: romeovs/lcov-reporter-action@87a815f34ec27a5826abba44ce09bbc688da58fd
         with:
           lcov-file: coverage/unit/coverage.lcov
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -217,10 +229,12 @@ jobs:
     needs: [unit-tests, integration-tests, security-tests]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: latest
 
@@ -229,7 +243,7 @@ jobs:
         run: echo "dir=$(bun pm cache)" >> $GITHUB_OUTPUT
 
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ${{ steps.bun-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
@@ -249,15 +263,17 @@ jobs:
     needs: [quality, type-check, unit-tests, integration-tests, security-tests, coverage-gate]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: latest
 
@@ -266,7 +282,7 @@ jobs:
         run: echo "dir=$(bun pm cache)" >> $GITHUB_OUTPUT
 
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ${{ steps.bun-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,11 +210,43 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           title: Unit Test Coverage
 
+  coverage-gate:
+    name: 80% Coverage Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [unit-tests, integration-tests, security-tests]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Get bun cache directory
+        id: bun-cache-dir
+        run: echo "dir=$(bun pm cache)" >> $GITHUB_OUTPUT
+
+      - name: Cache bun dependencies
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.bun-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run full coverage gate
+        run: bun run test:coverage
+
   build:
     name: Build & Verify
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [quality, type-check, unit-tests, integration-tests, security-tests]
+    needs: [quality, type-check, unit-tests, integration-tests, security-tests, coverage-gate]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -254,7 +286,7 @@ jobs:
     name: CI Success
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [quality, type-check, unit-tests, integration-tests, security-tests, build]
+    needs: [quality, type-check, unit-tests, integration-tests, security-tests, coverage-gate, build]
     if: always()
     steps:
       - name: Check all jobs status
@@ -264,6 +296,7 @@ jobs:
              [[ "${{ needs.unit-tests.result }}" != "success" ]] || \
              [[ "${{ needs.integration-tests.result }}" != "success" ]] || \
              [[ "${{ needs.security-tests.result }}" != "success" ]] || \
+             [[ "${{ needs.coverage-gate.result }}" != "success" ]] || \
              [[ "${{ needs.build.result }}" != "success" ]]; then
             echo "One or more CI jobs failed"
             exit 1

--- a/__tests__/unit/api/coverage-routes.test.ts
+++ b/__tests__/unit/api/coverage-routes.test.ts
@@ -1,0 +1,1052 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const cookieStore = {
+    value: null as string | null,
+    get: vi.fn(() => (cookieStore.value ? { value: cookieStore.value } : undefined)),
+    set: vi.fn((_name: string, value: string) => {
+      cookieStore.value = value;
+    }),
+    delete: vi.fn(() => {
+      cookieStore.value = null;
+    }),
+  };
+
+  const state = {
+    selectResults: [] as unknown[][],
+    authResult: null as unknown,
+    handleRateLimit: { allowed: true } as { allowed: boolean; message?: string },
+    emailRateLimit: { allowed: true } as { allowed: boolean; message?: string },
+    uploadRateLimit: {
+      allowed: true,
+      remaining: { hourly: 9, daily: 49 },
+    } as {
+      allowed: boolean;
+      message?: string;
+      remaining: { hourly: number; daily: number };
+    },
+    disposableResult: { disposable: false } as { disposable: boolean },
+    handleTaken: false,
+    themeError: null as Response | null,
+    requestSize: { valid: true } as { valid: boolean; error?: string },
+    adminAuthResult: {
+      user: { id: "admin_1", email: "admin@example.com", name: "Admin", isAdmin: true },
+      error: null,
+    } as unknown,
+    cookieStore,
+  };
+
+  const nextSelectResult = () => state.selectResults.shift() ?? [];
+  const createChain = (): Record<string, unknown> => {
+    const chain: Record<string, unknown> = {
+      from: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      leftJoin: vi.fn(() => chain),
+      orderBy: vi.fn(() => chain),
+      groupBy: vi.fn(() => chain),
+      limit: vi.fn(() => chain),
+      offset: vi.fn(() => chain),
+      values: vi.fn(() => chain),
+      set: vi.fn(() => chain),
+      onConflictDoNothing: vi.fn(() => chain),
+      onConflictDoUpdate: vi.fn(() => chain),
+      returning: vi.fn(() => chain),
+      // biome-ignore lint/suspicious/noThenProperty: Drizzle query mocks must be awaitable.
+      then: vi.fn((resolve: (value: unknown[]) => unknown) => resolve(nextSelectResult())),
+    };
+    return chain;
+  };
+
+  const db = {
+    query: {
+      user: { findFirst: vi.fn() },
+      siteData: { findFirst: vi.fn() },
+      resumes: { findFirst: vi.fn() },
+    },
+    select: vi.fn(() => createChain()),
+    insert: vi.fn(() => createChain()),
+    update: vi.fn(() => createChain()),
+    delete: vi.fn(() => createChain()),
+    batch: vi.fn(async () => undefined),
+  };
+
+  const env = {
+    CLICKFOLIO_DB: { prepare: vi.fn(() => ({ first: vi.fn(async () => ({ ok: 1 })) })) },
+    CLICKFOLIO_R2_BUCKET: { list: vi.fn(async () => ({ objects: [] })) },
+    CLICKFOLIO_DISPOSABLE_DOMAINS: { get: vi.fn(async () => "[]") },
+    CLICKFOLIO_PARSE_QUEUE: { send: vi.fn(async () => undefined) },
+    BETTER_AUTH_SECRET: "test-secret-key-for-pending-upload",
+    CF_AI_GATEWAY_ACCOUNT_ID: "acct",
+    CF_AI_GATEWAY_ID: "gateway",
+    CF_AIG_AUTH_TOKEN: "token",
+  };
+
+  return {
+    state,
+    db,
+    env,
+    getAuth: vi.fn(async () => ({
+      api: { getSession: vi.fn(async () => ({ user: { id: "user_1" } })) },
+    })),
+    authHandlerGet: vi.fn(async () => Response.json({ method: "GET" })),
+    authHandlerPost: vi.fn(async () => Response.json({ method: "POST" })),
+    getStats: vi.fn(async () => ({ pageviews: 10, visitors: 4 })),
+    getPageviews: vi.fn(async () => ({
+      pageviews: [{ x: "2026-05-20T00:00:00Z", y: 6 }],
+      sessions: [{ x: "2026-05-20T00:00:00Z", y: 2 }],
+    })),
+    getMetrics: vi.fn(async (_env: unknown, options: { type: string }) => {
+      if (options.type === "referrer") return [{ x: "linkedin.com", y: 3 }];
+      if (options.type === "device") return [{ x: "desktop", y: 5 }];
+      return [{ x: "US", y: 5 }];
+    }),
+    performCleanup: vi.fn(async () => ({ deleted: 1 })),
+    performR2Cleanup: vi.fn(async () => ({ deleted: 2 })),
+    syncDisposableDomains: vi.fn(async () => ({ synced: 3 })),
+    recoverOrphanedResumes: vi.fn(async () => ({ recovered: 4 })),
+    r2Put: vi.fn(async () => undefined),
+    r2Delete: vi.fn(async () => undefined),
+    r2GetAsUint8Array: vi.fn(async () => new Uint8Array([1, 2, 3])),
+    resvgAsync: vi.fn(async (_svg: string, _options?: unknown) => ({
+      render: () => ({
+        asPng: () => new Uint8Array([137, 80, 78, 71]),
+      }),
+    })),
+  };
+});
+
+vi.mock("cloudflare:workers", () => ({
+  env: mocks.env,
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => new Headers()),
+  cookies: vi.fn(async () => mocks.state.cookieStore),
+}));
+
+vi.mock("better-auth/next-js", () => ({
+  toNextJsHandler: vi.fn(() => ({ GET: mocks.authHandlerGet, POST: mocks.authHandlerPost })),
+}));
+
+vi.mock("@cf-wasm/resvg/workerd", () => ({
+  Resvg: {
+    async: mocks.resvgAsync,
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getAuth: mocks.getAuth,
+  getEnvValue: vi.fn((env: Record<string, string>, key: string) => env[key] || "fallback-secret"),
+}));
+
+vi.mock("@/lib/auth/middleware", () => ({
+  requireAuthWithUserValidation: vi.fn(async () => mocks.state.authResult),
+}));
+
+vi.mock("@/lib/auth/admin", () => ({
+  requireAdminAuthForApi: vi.fn(async () => mocks.state.adminAuthResult),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getDb: vi.fn(() => mocks.db),
+}));
+
+vi.mock("@/lib/rate-limit/ip", () => ({
+  getClientIP: vi.fn(() => "203.0.113.10"),
+  checkIPRateLimit: vi.fn(async () => mocks.state.uploadRateLimit),
+  checkHandleRateLimit: vi.fn(async () => mocks.state.handleRateLimit),
+  checkEmailValidateRateLimit: vi.fn(async () => mocks.state.emailRateLimit),
+}));
+
+vi.mock("@/lib/rate-limit/handle-validation", () => ({
+  RESERVED_HANDLES: new Set(["admin", "api"]),
+  isHandleTaken: vi.fn(async () => mocks.state.handleTaken),
+  isValidHandleFormat: vi.fn((handle: string) => /^[a-z0-9-]{3,30}$/.test(handle)),
+}));
+
+vi.mock("@/lib/email/disposable-check", () => ({
+  isDisposableEmail: vi.fn(async () => mocks.state.disposableResult),
+}));
+
+vi.mock("@/lib/templates/theme-access", () => ({
+  verifyThemeUnlocked: vi.fn(async () => mocks.state.themeError),
+}));
+
+vi.mock("@/lib/utils/validation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/utils/validation")>();
+  return {
+    ...actual,
+    validateRequestSize: vi.fn(() => mocks.state.requestSize),
+  };
+});
+
+vi.mock("@/lib/umami/client", () => ({
+  getStats: mocks.getStats,
+  getPageviews: mocks.getPageviews,
+  getMetrics: mocks.getMetrics,
+}));
+
+vi.mock("@/lib/cron/cleanup", () => ({
+  performCleanup: mocks.performCleanup,
+}));
+
+vi.mock("@/lib/cron/cleanup-r2", () => ({
+  performR2Cleanup: mocks.performR2Cleanup,
+}));
+
+vi.mock("@/lib/cron/sync-disposable-domains", () => ({
+  syncDisposableDomains: mocks.syncDisposableDomains,
+}));
+
+vi.mock("@/lib/cron/recover-orphaned", () => ({
+  recoverOrphanedResumes: mocks.recoverOrphanedResumes,
+}));
+
+vi.mock("@/lib/r2", () => ({
+  getR2Binding: vi.fn((env: typeof mocks.env) => env.CLICKFOLIO_R2_BUCKET),
+  R2: {
+    put: mocks.r2Put,
+    delete: mocks.r2Delete,
+    getAsUint8Array: mocks.r2GetAsUint8Array,
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  relations: vi.fn((_table, build) =>
+    build({
+      many: vi.fn((table) => ({ relation: "many", table })),
+      one: vi.fn((table, config) => ({ relation: "one", table, config })),
+    }),
+  ),
+  eq: vi.fn((_field, value) => ({ op: "eq", value })),
+  gt: vi.fn((_field, value) => ({ op: "gt", value })),
+  and: vi.fn((...conditions) => ({ op: "and", conditions })),
+  or: vi.fn((...conditions) => ({ op: "or", conditions })),
+  count: vi.fn(() => ({ op: "count" })),
+  desc: vi.fn((field) => ({ op: "desc", field })),
+  isNotNull: vi.fn((field) => ({ op: "isNotNull", field })),
+  sql: Object.assign(
+    vi.fn((strings, ...values) => ({ op: "sql", strings, values })),
+    {
+      join: vi.fn((items, separator) => ({ op: "sql.join", items, separator })),
+    },
+  ),
+}));
+
+function jsonRequest(path: string, body: unknown, init: RequestInit = {}) {
+  return new Request(`https://clickfolio.me${path}`, {
+    method: init.method ?? "POST",
+    headers: { "content-type": "application/json", ...(init.headers ?? {}) },
+    body: JSON.stringify(body),
+  });
+}
+
+function authed(overrides: Record<string, unknown> = {}) {
+  mocks.state.authResult = {
+    user: { id: "user_1", email: "avery@example.com" },
+    dbUser: { id: "user_1", handle: "avery" },
+    db: mocks.db,
+    env: mocks.env,
+    captureBookmark: vi.fn(async () => undefined),
+    error: null,
+    ...overrides,
+  };
+}
+
+describe("API route coverage", () => {
+  beforeEach(() => {
+    process.env.CRON_SECRET = "cron-secret";
+    vi.clearAllMocks();
+    mocks.state.selectResults = [];
+    mocks.state.authResult = null;
+    mocks.state.handleRateLimit = { allowed: true };
+    mocks.state.emailRateLimit = { allowed: true };
+    mocks.state.uploadRateLimit = {
+      allowed: true,
+      remaining: { hourly: 9, daily: 49 },
+    };
+    mocks.state.disposableResult = { disposable: false };
+    mocks.state.handleTaken = false;
+    mocks.state.themeError = null;
+    mocks.state.requestSize = { valid: true };
+    mocks.state.adminAuthResult = {
+      user: { id: "admin_1", email: "admin@example.com", name: "Admin", isAdmin: true },
+      error: null,
+    };
+    mocks.state.cookieStore.value = null;
+    mocks.db.query.user.findFirst.mockResolvedValue(null);
+    mocks.db.query.siteData.findFirst.mockResolvedValue(null);
+    mocks.db.query.resumes.findFirst.mockResolvedValue(null);
+    mocks.env.CLICKFOLIO_DB.prepare.mockReturnValue({ first: vi.fn(async () => ({ ok: 1 })) });
+    mocks.env.CLICKFOLIO_R2_BUCKET.list.mockResolvedValue({ objects: [] });
+    mocks.r2Put.mockResolvedValue(undefined);
+    mocks.r2Delete.mockResolvedValue(undefined);
+    mocks.r2GetAsUint8Array.mockResolvedValue(new Uint8Array([1, 2, 3]));
+    mocks.resvgAsync.mockResolvedValue({
+      render: () => ({
+        asPng: () => new Uint8Array([137, 80, 78, 71]),
+      }),
+    });
+  });
+
+  it("exercises handle availability validation and ownership branches", async () => {
+    const { GET } = await import("@/app/api/handle/check/route");
+
+    expect((await GET(new Request("https://clickfolio.me/api/handle/check"))).status).toBe(400);
+    expect(
+      (await GET(new Request("https://clickfolio.me/api/handle/check?handle=ab"))).status,
+    ).toBe(400);
+    expect(
+      (await GET(new Request(`https://clickfolio.me/api/handle/check?handle=${"a".repeat(31)}`)))
+        .status,
+    ).toBe(400);
+    expect(
+      (await GET(new Request("https://clickfolio.me/api/handle/check?handle=bad_name"))).status,
+    ).toBe(400);
+    expect(
+      (await GET(new Request("https://clickfolio.me/api/handle/check?handle=-bad"))).status,
+    ).toBe(400);
+    expect(
+      (await GET(new Request("https://clickfolio.me/api/handle/check?handle=bad--name"))).status,
+    ).toBe(400);
+
+    expect(
+      await (await GET(new Request("https://clickfolio.me/api/handle/check?handle=admin"))).json(),
+    ).toEqual({ available: false, reason: "reserved" });
+
+    mocks.state.handleRateLimit = { allowed: false, message: "slow down" };
+    expect(
+      (await GET(new Request("https://clickfolio.me/api/handle/check?handle=rate-test"))).status,
+    ).toBe(429);
+
+    mocks.state.handleRateLimit = { allowed: true };
+    mocks.state.selectResults = [[]];
+    expect(
+      await (
+        await GET(new Request("https://clickfolio.me/api/handle/check?handle=new-handle"))
+      ).json(),
+    ).toEqual({ available: true });
+
+    mocks.state.selectResults = [[{ id: "user_1" }]];
+    expect(
+      await (await GET(new Request("https://clickfolio.me/api/handle/check?handle=avery"))).json(),
+    ).toEqual({ available: true, isCurrentHandle: true });
+
+    mocks.state.selectResults = [[{ id: "other_user" }]];
+    expect(
+      await (await GET(new Request("https://clickfolio.me/api/handle/check?handle=taken"))).json(),
+    ).toEqual({ available: false });
+  });
+
+  it("validates disposable email requests and fails open on service errors", async () => {
+    const { POST } = await import("@/app/api/email/validate/route");
+
+    expect((await POST(new Request("https://clickfolio.me/api/email/validate"))).status).toBe(400);
+    expect((await POST(jsonRequest("/api/email/validate", { email: "bad" }))).status).toBe(400);
+
+    mocks.state.emailRateLimit = { allowed: false, message: "too many" };
+    expect(
+      (await POST(jsonRequest("/api/email/validate", { email: "a@example.com" }))).status,
+    ).toBe(429);
+
+    mocks.state.emailRateLimit = { allowed: true };
+    mocks.state.disposableResult = { disposable: true };
+    expect(
+      await (await POST(jsonRequest("/api/email/validate", { email: "a@example.com" }))).json(),
+    ).toEqual({ valid: false, reason: "Please use a permanent email address" });
+
+    mocks.state.disposableResult = { disposable: false };
+    expect(
+      await (await POST(jsonRequest("/api/email/validate", { email: "a@example.com" }))).json(),
+    ).toEqual({ valid: true });
+  });
+
+  it("aggregates analytics across current and historical handles", async () => {
+    const { GET } = await import("@/app/api/analytics/stats/route");
+    authed();
+
+    expect(
+      (await GET(new Request("https://clickfolio.me/api/analytics/stats?period=bad"))).status,
+    ).toBe(400);
+
+    authed({ dbUser: { id: "user_1", handle: null } });
+    expect(
+      await (await GET(new Request("https://clickfolio.me/api/analytics/stats?period=7d"))).json(),
+    ).toMatchObject({ totalViews: 0, period: "7d" });
+
+    authed();
+    mocks.state.selectResults = [[{ oldHandle: "old-one" }, { oldHandle: null }]];
+    const response = await GET(new Request("https://clickfolio.me/api/analytics/stats?period=30d"));
+    const body = (await response.json()) as { viewsByDay: unknown[] } & Record<string, unknown>;
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      totalViews: 20,
+      uniqueVisitors: 8,
+      topReferrers: [{ referrer: "linkedin.com", count: 6 }],
+      directVisits: 14,
+      period: "30d",
+    });
+    expect(body.viewsByDay).toHaveLength(30);
+
+    mocks.getStats.mockRejectedValueOnce(new Error("umami down"));
+    mocks.state.selectResults = [[]];
+    expect((await GET(new Request("https://clickfolio.me/api/analytics/stats"))).status).toBe(503);
+  });
+
+  it("returns site data and user stats for authenticated users", async () => {
+    const siteDataRoute = await import("@/app/api/site-data/route");
+    const userStatsRoute = await import("@/app/api/user/stats/route");
+
+    authed({ error: new Response("nope", { status: 401 }) });
+    expect((await siteDataRoute.GET()).status).toBe(401);
+    expect((await userStatsRoute.GET()).status).toBe(401);
+
+    authed();
+    mocks.state.selectResults = [[]];
+    expect(await (await siteDataRoute.GET()).json()).toBeNull();
+
+    authed();
+    mocks.state.selectResults = [
+      [
+        {
+          id: "site_1",
+          userId: "user_1",
+          resumeId: "res_1",
+          content: '{"full_name":"Avery"}',
+          themeId: "minimalist_editorial",
+          lastPublishedAt: "2026-05-20T00:00:00Z",
+          createdAt: "2026-05-20T00:00:00Z",
+          updatedAt: "2026-05-20T00:00:00Z",
+        },
+      ],
+    ];
+    expect(await (await siteDataRoute.GET()).json()).toMatchObject({
+      id: "site_1",
+      content: { full_name: "Avery" },
+    });
+
+    authed();
+    mocks.db.query.user.findFirst.mockResolvedValueOnce(null);
+    expect((await userStatsRoute.GET()).status).toBe(404);
+
+    authed();
+    mocks.db.query.user.findFirst.mockResolvedValueOnce({ referralCount: 5, isPro: true });
+    expect(await (await userStatsRoute.GET()).json()).toEqual({ referralCount: 5, isPro: true });
+  });
+
+  it("tracks referrals without leaking validation or storage failures", async () => {
+    const { POST } = await import("@/app/api/referral/track/route");
+
+    expect((await POST(new Request("https://clickfolio.me/api/referral/track"))).status).toBe(204);
+    expect((await POST(jsonRequest("/api/referral/track", {}))).status).toBe(204);
+    expect((await POST(jsonRequest("/api/referral/track", { code: "x".repeat(65) }))).status).toBe(
+      204,
+    );
+    expect(
+      (
+        await POST(
+          jsonRequest(
+            "/api/referral/track",
+            { code: "avery" },
+            { headers: { "user-agent": "Googlebot/2.1" } },
+          ),
+        )
+      ).status,
+    ).toBe(204);
+
+    mocks.state.selectResults = [[]];
+    expect(
+      (
+        await POST(
+          jsonRequest(
+            "/api/referral/track",
+            { handle: "avery", source: "bad" },
+            { headers: { "user-agent": "Mozilla/5.0 Test Browser" } },
+          ),
+        )
+      ).status,
+    ).toBe(204);
+
+    mocks.state.selectResults = [[{ id: "user_2" }]];
+    expect(
+      (
+        await POST(
+          jsonRequest(
+            "/api/referral/track",
+            { code: "ABC123", source: "share" },
+            { headers: { "user-agent": "Mozilla/5.0 Test Browser" } },
+          ),
+        )
+      ).status,
+    ).toBe(204);
+    expect(mocks.db.insert).toHaveBeenCalled();
+  });
+
+  it("manages pending upload cookies with signed values", async () => {
+    const { POST, GET, DELETE } = await import("@/app/api/upload/pending/route");
+
+    expect((await POST(jsonRequest("/api/upload/pending", { key: "bad/key" }))).status).toBe(400);
+
+    expect(
+      (await POST(jsonRequest("/api/upload/pending", { key: "temp/upload.pdf" }))).status,
+    ).toBe(200);
+    expect(mocks.state.cookieStore.set).toHaveBeenCalled();
+    expect(await (await GET()).json()).toEqual({ key: "temp/upload.pdf" });
+
+    mocks.state.cookieStore.value = "not-a-valid-cookie";
+    expect(await (await GET()).json()).toEqual({ key: null });
+
+    expect((await DELETE()).status).toBe(200);
+    expect(mocks.state.cookieStore.delete).toHaveBeenCalled();
+  });
+
+  it("validates direct uploads before storing PDFs in R2", async () => {
+    const { POST } = await import("@/app/api/upload/route");
+    const originalBucket = mocks.env.CLICKFOLIO_R2_BUCKET;
+    const pdf = new Uint8Array(120);
+    pdf.set([0x25, 0x50, 0x44, 0x46]); // %PDF
+
+    const uploadRequest = (overrides: { headers?: HeadersInit; body?: BodyInit } = {}) =>
+      new Request("https://clickfolio.me/api/upload", {
+        method: "POST",
+        headers: {
+          "content-type": "application/pdf",
+          "content-length": String(
+            (overrides.body as Uint8Array | undefined)?.byteLength ?? pdf.byteLength,
+          ),
+          "x-filename": "resume.pdf",
+          ...(overrides.headers ?? {}),
+        },
+        body: overrides.body ?? pdf,
+      });
+
+    (mocks.env as { CLICKFOLIO_R2_BUCKET?: unknown }).CLICKFOLIO_R2_BUCKET = undefined;
+    expect((await POST(uploadRequest())).status).toBe(503);
+    mocks.env.CLICKFOLIO_R2_BUCKET = originalBucket;
+
+    expect(
+      (
+        await POST(
+          uploadRequest({
+            headers: { "content-type": "text/plain" },
+          }),
+        )
+      ).status,
+    ).toBe(400);
+    expect((await POST(uploadRequest({ headers: { "content-length": "" } }))).status).toBe(411);
+    expect((await POST(uploadRequest({ headers: { "content-length": "nope" } }))).status).toBe(400);
+    expect((await POST(uploadRequest({ headers: { "content-length": "20000000" } }))).status).toBe(
+      413,
+    );
+    expect(
+      (await POST(uploadRequest({ headers: { "content-length": "10" }, body: pdf.slice(0, 10) })))
+        .status,
+    ).toBe(400);
+    expect((await POST(uploadRequest({ headers: { "x-filename": "" } }))).status).toBe(400);
+    expect(
+      (await POST(uploadRequest({ headers: { "x-filename": `${"a".repeat(256)}.pdf` } }))).status,
+    ).toBe(400);
+
+    mocks.state.uploadRateLimit = {
+      allowed: false,
+      message: "too many uploads",
+      remaining: { hourly: 0, daily: 0 },
+    };
+    expect((await POST(uploadRequest())).status).toBe(429);
+
+    mocks.state.uploadRateLimit = {
+      allowed: true,
+      remaining: { hourly: 9, daily: 49 },
+    };
+    expect((await POST(uploadRequest({ headers: { "content-length": "121" } }))).status).toBe(400);
+
+    const invalidPdf = new Uint8Array(120);
+    expect((await POST(uploadRequest({ body: invalidPdf }))).status).toBe(400);
+
+    mocks.r2Put.mockRejectedValueOnce(new Error("r2 down"));
+    expect((await POST(uploadRequest())).status).toBe(500);
+
+    const success = await POST(uploadRequest());
+    expect(success.status).toBe(200);
+    expect(await success.json()).toMatchObject({
+      remaining: { hourly: 9, daily: 49 },
+    });
+    expect(mocks.r2Put).toHaveBeenLastCalledWith(
+      originalBucket,
+      expect.stringMatching(/^temp\//),
+      expect.any(ArrayBuffer),
+      expect.objectContaining({
+        contentType: "application/pdf",
+        customMetadata: expect.objectContaining({ originalFilename: "resume.pdf" }),
+      }),
+    );
+    expect(success.headers.get("X-RateLimit-Remaining-Hourly")).toBe("9");
+    expect(success.headers.get("Set-Cookie")).toContain("pending_upload=");
+  });
+
+  it("deletes account data, clears auth cookies, and reports partial storage warnings", async () => {
+    const { POST } = await import("@/app/api/account/delete/route");
+    const originalBucket = mocks.env.CLICKFOLIO_R2_BUCKET;
+
+    authed({ error: new Response("auth", { status: 401 }) });
+    expect(
+      (await POST(jsonRequest("/api/account/delete", { confirmation: "avery@example.com" })))
+        .status,
+    ).toBe(401);
+
+    authed();
+    (mocks.env as { CLICKFOLIO_R2_BUCKET?: unknown }).CLICKFOLIO_R2_BUCKET = undefined;
+    expect(
+      (await POST(jsonRequest("/api/account/delete", { confirmation: "avery@example.com" })))
+        .status,
+    ).toBe(500);
+    mocks.env.CLICKFOLIO_R2_BUCKET = originalBucket;
+
+    authed();
+    expect(
+      (
+        await POST(
+          new Request("https://clickfolio.me/api/account/delete", { method: "POST", body: "{" }),
+        )
+      ).status,
+    ).toBe(400);
+    expect(
+      (await POST(jsonRequest("/api/account/delete", { confirmation: "not-an-email" }))).status,
+    ).toBe(400);
+    expect(
+      (await POST(jsonRequest("/api/account/delete", { confirmation: "wrong@example.com" })))
+        .status,
+    ).toBe(400);
+
+    authed();
+    mocks.state.selectResults = [[{ r2Key: "one.pdf" }, { r2Key: null }, { r2Key: "two.pdf" }]];
+    mocks.r2Delete
+      .mockRejectedValueOnce(new Error("delete failed"))
+      .mockResolvedValueOnce(undefined);
+    const success = await POST(
+      jsonRequest("/api/account/delete", { confirmation: "AVERY@EXAMPLE.COM" }),
+    );
+
+    expect(success.status).toBe(200);
+    expect(await success.json()).toMatchObject({
+      success: true,
+      warnings: [{ type: "r2", message: "Failed to delete file: one.pdf" }],
+    });
+    expect(mocks.r2Delete).toHaveBeenCalledWith(originalBucket, "one.pdf");
+    expect(mocks.r2Delete).toHaveBeenCalledWith(originalBucket, "two.pdf");
+    expect(mocks.db.batch).toHaveBeenCalled();
+    expect(success.headers.get("Set-Cookie")).toContain("better-auth.session_token=");
+
+    authed();
+    mocks.state.selectResults = [[{ r2Key: "three.pdf" }]];
+    mocks.db.batch.mockRejectedValueOnce(new Error("db down"));
+    expect(
+      (await POST(jsonRequest("/api/account/delete", { confirmation: "avery@example.com" })))
+        .status,
+    ).toBe(500);
+  });
+
+  it("renders static and dynamic OG images with resilient fallbacks", async () => {
+    const home = await import("@/app/api/og/home/route");
+    const dynamic = await import("@/app/api/og/[handle]/route");
+
+    const homeResponse = await home.GET();
+    expect(homeResponse.headers.get("Content-Type")).toBe("image/svg+xml");
+    expect(await homeResponse.text()).toContain("clickfolio");
+
+    const emptyHandle = await dynamic.GET(new Request("https://clickfolio.me/api/og/"), {
+      params: Promise.resolve({ handle: "" }),
+    });
+    expect(emptyHandle.headers.get("Content-Type")).toBe("image/png");
+
+    mocks.state.selectResults = [[]];
+    const missing = await dynamic.GET(new Request("https://clickfolio.me/api/og/missing"), {
+      params: Promise.resolve({ handle: "missing" }),
+    });
+    expect(missing.headers.get("Content-Type")).toBe("image/png");
+
+    mocks.state.selectResults = [
+      [
+        {
+          name: "Avery & Quinn",
+          handle: "avery",
+          previewName: "Avery <Lead>",
+          previewHeadline: "Builds > ships",
+          previewSkills: JSON.stringify(["TypeScript", "Cloudflare", "D1", "R2", "Hidden"]),
+        },
+      ],
+    ];
+    const profile = await dynamic.GET(new Request("https://clickfolio.me/api/og/%40avery"), {
+      params: Promise.resolve({ handle: "%40avery" }),
+    });
+    expect(profile.headers.get("Content-Type")).toBe("image/png");
+    expect(mocks.resvgAsync).toHaveBeenLastCalledWith(
+      expect.stringContaining("Avery &lt;Lead&gt;"),
+      expect.any(Object),
+    );
+    expect(mocks.resvgAsync.mock.calls.at(-1)?.[0]).not.toContain("Hidden");
+
+    mocks.resvgAsync.mockRejectedValueOnce(new Error("wasm failed"));
+    mocks.state.selectResults = [
+      [
+        {
+          name: "Broken Renderer",
+          handle: "broken",
+          previewName: null,
+          previewHeadline: null,
+          previewSkills: null,
+        },
+      ],
+    ];
+    const fallback = await dynamic.GET(new Request("https://clickfolio.me/api/og/broken"), {
+      params: Promise.resolve({ handle: "broken" }),
+    });
+    expect(fallback.headers.get("Content-Type")).toBe("image/svg+xml");
+  });
+
+  it("summarizes admin referrals including empty, unknown, and attributed branches", async () => {
+    const { GET } = await import("@/app/api/admin/referrals/route");
+
+    mocks.state.adminAuthResult = { user: null, error: new Response("admin", { status: 403 }) };
+    expect((await GET()).status).toBe(403);
+
+    mocks.state.adminAuthResult = {
+      user: { id: "admin_1", email: "admin@example.com", name: "Admin", isAdmin: true },
+      error: null,
+    };
+    mocks.state.selectResults = [
+      [{ count: 2 }],
+      [{ totalClicks: 10, uniqueClicks: 5, attributedConversions: 2 }],
+      [{ count: 3 }],
+      [
+        { source: "share", count: 7 },
+        { source: null, count: 3 },
+      ],
+      [
+        { userId: "user_1", handle: "avery", referralCount: 3 },
+        { userId: "user_2", handle: null, referralCount: 1 },
+      ],
+      [
+        {
+          newUserEmail: null,
+          referrerUserId: "user_1",
+          referredAt: null,
+          createdAt: "2026-05-20T00:00:00Z",
+        },
+      ],
+      [{ referrerUserId: "user_1", clicks: 6 }],
+      [{ id: "user_1", handle: "avery" }],
+    ];
+
+    const body = (await (await GET()).json()) as {
+      stats: unknown;
+      topReferrers: unknown;
+      sources: unknown;
+      recentConversions: unknown;
+    };
+    expect(body.stats).toMatchObject({
+      totalReferrers: 2,
+      totalClicks: 10,
+      conversions: 3,
+      conversionRate: 60,
+      attributedConversions: 2,
+      attributedConversionRate: 40,
+      unattributedConversions: 1,
+    });
+    expect(body.topReferrers).toEqual([
+      { handle: "avery", clicks: 6, conversions: 3, rate: "50.0" },
+      { handle: "unknown", clicks: 0, conversions: 1, rate: "0" },
+    ]);
+    expect(body.sources).toEqual([
+      { source: "share", percent: 70 },
+      { source: "unknown", percent: 30 },
+    ]);
+    expect(body.recentConversions).toEqual([
+      {
+        newUserEmail: "Unknown",
+        referrerHandle: "avery",
+        createdAt: "2026-05-20T00:00:00Z",
+      },
+    ]);
+
+    mocks.db.select.mockImplementationOnce(() => {
+      throw new Error("db down");
+    });
+    expect((await GET()).status).toBe(500);
+  });
+
+  it("paginates admin users with search escaping and derived status labels", async () => {
+    const { GET } = await import("@/app/api/admin/users/route");
+
+    mocks.state.selectResults = [[{ count: 0 }], []];
+    expect(
+      await (await GET(new Request("https://clickfolio.me/api/admin/users?page=-3"))).json(),
+    ).toEqual({ users: [], total: 0, page: 1, pageSize: 25 });
+
+    mocks.state.selectResults = [
+      [{ count: 4 }],
+      [
+        {
+          id: "failed",
+          name: "Failed User",
+          email: "failed@example.com",
+          handle: "failed",
+          createdAt: "2026-05-20",
+          isPro: false,
+        },
+        {
+          id: "processing",
+          name: "Processing User",
+          email: "processing@example.com",
+          handle: "processing",
+          createdAt: "2026-05-19",
+          isPro: false,
+        },
+        {
+          id: "live",
+          name: "Live User",
+          email: "live@example.com",
+          handle: "live",
+          createdAt: "2026-05-18",
+          isPro: true,
+        },
+        {
+          id: "empty",
+          name: "Empty User",
+          email: "empty@example.com",
+          handle: null,
+          createdAt: "2026-05-17",
+          isPro: false,
+        },
+      ],
+      [
+        { userId: "failed", status: "completed" },
+        { userId: "failed", status: "failed" },
+        { userId: "processing", status: "queued" },
+      ],
+      [{ userId: "live" }],
+    ];
+
+    const body = (await (
+      await GET(new Request("https://clickfolio.me/api/admin/users?page=2&search=a%25_%5C"))
+    ).json()) as { page: number; users: Array<{ status: string }> };
+    expect(body.page).toBe(2);
+    expect(body.users.map((entry: { status: string }) => entry.status)).toEqual([
+      "failed",
+      "processing",
+      "live",
+      "no_resume",
+    ]);
+
+    mocks.db.select.mockImplementationOnce(() => {
+      throw new Error("db down");
+    });
+    expect((await GET(new Request("https://clickfolio.me/api/admin/users"))).status).toBe(500);
+  });
+
+  it("filters admin resumes and folds internal statuses into dashboard buckets", async () => {
+    const { GET } = await import("@/app/api/admin/resumes/route");
+
+    expect(
+      (await GET(new Request("https://clickfolio.me/api/admin/resumes?status=bad"))).status,
+    ).toBe(400);
+
+    mocks.state.selectResults = [
+      [
+        { status: "completed", count: 2 },
+        { status: "waiting_for_cache", count: 1 },
+        { status: "processing", count: 3 },
+        { status: "queued", count: 4 },
+        { status: "pending_claim", count: 5 },
+        { status: "failed", count: 6 },
+        { status: "unknown", count: 7 },
+      ],
+      [{ count: 1 }],
+      [
+        {
+          id: "resume_1",
+          userId: "user_1",
+          status: "failed",
+          retryCount: 2,
+          totalAttempts: 4,
+          lastAttemptError: null,
+          errorMessage: "Parse failed",
+          queuedAt: null,
+          updatedAt: null,
+          createdAt: "2026-05-20",
+          userEmail: null,
+        },
+      ],
+    ];
+
+    const body = (await (
+      await GET(new Request("https://clickfolio.me/api/admin/resumes?status=failed&page=2"))
+    ).json()) as { stats: unknown; resumes: unknown; page: number };
+    expect(body.stats).toEqual({ completed: 3, processing: 3, queued: 9, failed: 6 });
+    expect(body.resumes).toEqual([
+      {
+        id: "resume_1",
+        userEmail: "Unknown",
+        status: "failed",
+        retryCount: 2,
+        totalAttempts: 4,
+        lastAttemptError: "Parse failed",
+        updatedAt: "2026-05-20",
+      },
+    ]);
+    expect(body.page).toBe(2);
+
+    mocks.db.select.mockImplementationOnce(() => {
+      throw new Error("db down");
+    });
+    expect((await GET(new Request("https://clickfolio.me/api/admin/resumes"))).status).toBe(500);
+  });
+
+  it("combines admin dashboard stats with Umami sparkline data", async () => {
+    const { GET } = await import("@/app/api/admin/stats/route");
+
+    mocks.state.selectResults = [
+      [{ total: 8 }],
+      [{ count: 5 }],
+      [
+        { status: "processing", count: 2 },
+        { status: "queued", count: 3 },
+        { status: "failed", count: 1 },
+        { status: null, count: 9 },
+      ],
+      [
+        { email: "new@example.com", createdAt: "2026-05-20" },
+        { email: "old@example.com", createdAt: "2026-05-19" },
+      ],
+    ];
+    mocks.getStats.mockResolvedValueOnce({ pageviews: 12, visitors: 4 });
+    mocks.getPageviews.mockResolvedValueOnce({
+      pageviews: [{ x: new Date().toISOString(), y: 9 }],
+      sessions: [],
+    });
+
+    const body = (await (await GET()).json()) as {
+      dailyViews: Array<{ views: number }>;
+    } & Record<string, unknown>;
+    expect(body).toMatchObject({
+      totalUsers: 8,
+      publishedResumes: 5,
+      processingResumes: 5,
+      viewsToday: 12,
+      failedResumes: 1,
+      recentSignups: [
+        { email: "new@example.com", createdAt: "2026-05-20" },
+        { email: "old@example.com", createdAt: "2026-05-19" },
+      ],
+    });
+    expect(body.dailyViews).toHaveLength(7);
+    expect(body.dailyViews.at(-1)?.views).toBe(9);
+
+    mocks.getStats.mockRejectedValueOnce(new Error("umami down"));
+    expect((await GET()).status).toBe(503);
+  });
+
+  it("completes wizard onboarding and handles validation failures", async () => {
+    const { POST } = await import("@/app/api/wizard/complete/route");
+    const validBody = {
+      handle: "avery",
+      privacy_settings: {
+        show_phone: true,
+        show_address: false,
+        hide_from_search: false,
+        show_in_directory: true,
+      },
+      theme_id: "minimalist_editorial",
+    };
+
+    mocks.state.requestSize = { valid: false, error: "too large" };
+    expect((await POST(jsonRequest("/api/wizard/complete", validBody))).status).toBe(413);
+
+    mocks.state.requestSize = { valid: true };
+    authed({ error: new Response("auth", { status: 401 }) });
+    expect((await POST(jsonRequest("/api/wizard/complete", validBody))).status).toBe(401);
+
+    authed();
+    expect(
+      (await POST(new Request("https://clickfolio.me/api/wizard/complete", { method: "POST" })))
+        .status,
+    ).toBe(400);
+    expect(
+      (await POST(jsonRequest("/api/wizard/complete", { ...validBody, handle: "x" }))).status,
+    ).toBe(400);
+
+    mocks.state.themeError = new Response("locked", { status: 403 });
+    expect((await POST(jsonRequest("/api/wizard/complete", validBody))).status).toBe(403);
+
+    mocks.state.themeError = null;
+    mocks.state.handleTaken = true;
+    expect((await POST(jsonRequest("/api/wizard/complete", validBody))).status).toBe(400);
+
+    mocks.state.handleTaken = false;
+    expect(await (await POST(jsonRequest("/api/wizard/complete", validBody))).json()).toMatchObject(
+      {
+        success: true,
+        handle: "avery",
+      },
+    );
+
+    mocks.db.batch.mockRejectedValueOnce(new Error("UNIQUE constraint failed: user.handle"));
+    expect((await POST(jsonRequest("/api/wizard/complete", validBody))).status).toBe(409);
+  });
+
+  it("covers health, client-error, cron, and auth wrappers", async () => {
+    const health = await import("@/app/api/health/route");
+    const clientError = await import("@/app/api/client-error/route");
+    const auth = await import("@/app/api/auth/[...all]/route");
+    const cleanup = await import("@/app/api/cron/cleanup/route");
+    const cleanupR2 = await import("@/app/api/cron/cleanup-r2/route");
+    const syncDomains = await import("@/app/api/cron/sync-domains/route");
+    const recover = await import("@/app/api/cron/recover-orphaned/route");
+
+    expect((await health.GET()).status).toBe(200);
+    mocks.env.CLICKFOLIO_DB.prepare.mockReturnValueOnce({
+      first: vi.fn(async () => {
+        throw new Error("db down");
+      }),
+    });
+    expect((await health.GET()).status).toBe(503);
+
+    expect(
+      (await clientError.POST(new Request("https://clickfolio.me/api/client-error"))).status,
+    ).toBe(204);
+    expect((await clientError.POST(jsonRequest("/api/client-error", { message: 1 }))).status).toBe(
+      204,
+    );
+    expect(
+      (
+        await clientError.POST(
+          jsonRequest("/api/client-error", {
+            message: "boom".repeat(400),
+            stack: "stack",
+            componentStack: "component",
+            url: "https://clickfolio.me/dashboard",
+          }),
+        )
+      ).status,
+    ).toBe(204);
+
+    expect((await auth.GET(new Request("https://clickfolio.me/api/auth/session"))).status).toBe(
+      200,
+    );
+    expect((await auth.POST(new Request("https://clickfolio.me/api/auth/signout"))).status).toBe(
+      200,
+    );
+
+    const cronRequest = new Request("https://clickfolio.me/api/cron/cleanup", {
+      headers: { Authorization: "Bearer cron-secret" },
+    });
+    expect((await cleanup.GET(new Request("https://clickfolio.me/api/cron/cleanup"))).status).toBe(
+      401,
+    );
+    expect(await (await cleanup.GET(cronRequest)).json()).toEqual({ deleted: 1 });
+    expect(await (await cleanupR2.GET(cronRequest)).json()).toEqual({ deleted: 2 });
+    expect(await (await syncDomains.GET(cronRequest)).json()).toEqual({ synced: 3 });
+    expect(await (await recover.GET(cronRequest)).json()).toEqual({ recovered: 4 });
+  });
+});

--- a/__tests__/unit/api/coverage-routes.test.ts
+++ b/__tests__/unit/api/coverage-routes.test.ts
@@ -36,7 +36,14 @@ const mocks = vi.hoisted(() => {
     cookieStore,
   };
 
-  const nextSelectResult = () => state.selectResults.shift() ?? [];
+  const nextSelectResult = () => {
+    if (state.selectResults.length === 0) {
+      throw new Error(
+        "No select result queued — push to mocks.state.selectResults before querying",
+      );
+    }
+    return state.selectResults.shift() as unknown[];
+  };
   const createChain = (): Record<string, unknown> => {
     const chain: Record<string, unknown> = {
       from: vi.fn(() => chain),
@@ -53,7 +60,15 @@ const mocks = vi.hoisted(() => {
       onConflictDoUpdate: vi.fn(() => chain),
       returning: vi.fn(() => chain),
       // biome-ignore lint/suspicious/noThenProperty: Drizzle query mocks must be awaitable.
-      then: vi.fn((resolve: (value: unknown[]) => unknown) => resolve(nextSelectResult())),
+      then: vi.fn(
+        (resolve: (value: unknown[]) => unknown, reject?: (reason: unknown) => unknown) => {
+          try {
+            return Promise.resolve(resolve(nextSelectResult()));
+          } catch (error) {
+            return reject ? Promise.reject(reject(error)) : Promise.reject(error);
+          }
+        },
+      ),
     };
     return chain;
   };
@@ -246,6 +261,18 @@ function jsonRequest(path: string, body: unknown, init: RequestInit = {}) {
 }
 
 function authed(overrides: Record<string, unknown> = {}) {
+  if ("error" in overrides && overrides.error != null) {
+    mocks.state.authResult = {
+      user: null,
+      dbUser: null,
+      db: null,
+      env: null,
+      captureBookmark: null,
+      error: overrides.error,
+    };
+    return;
+  }
+
   mocks.state.authResult = {
     user: { id: "user_1", email: "avery@example.com" },
     dbUser: { id: "user_1", handle: "avery" },
@@ -302,6 +329,7 @@ describe("API route coverage", () => {
     } else {
       process.env.CRON_SECRET = originalCronSecret;
     }
+    expect(mocks.state.selectResults).toEqual([]);
   });
 
   it("exercises handle availability validation and ownership branches", async () => {

--- a/__tests__/unit/api/coverage-routes.test.ts
+++ b/__tests__/unit/api/coverage-routes.test.ts
@@ -159,11 +159,14 @@ vi.mock("@/lib/rate-limit/ip", () => ({
   checkEmailValidateRateLimit: vi.fn(async () => mocks.state.emailRateLimit),
 }));
 
-vi.mock("@/lib/rate-limit/handle-validation", () => ({
-  RESERVED_HANDLES: new Set(["admin", "api"]),
-  isHandleTaken: vi.fn(async () => mocks.state.handleTaken),
-  isValidHandleFormat: vi.fn((handle: string) => /^[a-z0-9-]{3,30}$/.test(handle)),
-}));
+vi.mock("@/lib/rate-limit/handle-validation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/rate-limit/handle-validation")>();
+  return {
+    ...actual,
+    RESERVED_HANDLES: new Set(["admin", "api"]),
+    isHandleTaken: vi.fn(async () => mocks.state.handleTaken),
+  };
+});
 
 vi.mock("@/lib/email/disposable-check", () => ({
   isDisposableEmail: vi.fn(async () => mocks.state.disposableResult),

--- a/__tests__/unit/api/coverage-routes.test.ts
+++ b/__tests__/unit/api/coverage-routes.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
   const cookieStore = {
@@ -258,7 +258,10 @@ function authed(overrides: Record<string, unknown> = {}) {
 }
 
 describe("API route coverage", () => {
+  let originalCronSecret: string | undefined;
+
   beforeEach(() => {
+    originalCronSecret = process.env.CRON_SECRET;
     process.env.CRON_SECRET = "cron-secret";
     vi.clearAllMocks();
     mocks.state.selectResults = [];
@@ -291,6 +294,14 @@ describe("API route coverage", () => {
         asPng: () => new Uint8Array([137, 80, 78, 71]),
       }),
     });
+  });
+
+  afterEach(() => {
+    if (originalCronSecret === undefined) {
+      delete process.env.CRON_SECRET;
+    } else {
+      process.env.CRON_SECRET = originalCronSecret;
+    }
   });
 
   it("exercises handle availability validation and ownership branches", async () => {

--- a/__tests__/unit/app/auth-pages.test.tsx
+++ b/__tests__/unit/app/auth-pages.test.tsx
@@ -1,0 +1,212 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import VerifyEmailPage from "@/app/(public)/verify-email/page";
+import ResetPasswordPage from "@/app/reset-password/page";
+
+type AuthActionResult = {
+  data: unknown | null;
+  error: { message?: string } | null;
+};
+
+const mocks = vi.hoisted(() => ({
+  search: "",
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+  resetPassword: vi.fn(
+    async (_params?: unknown): Promise<AuthActionResult> => ({
+      data: {},
+      error: null,
+    }),
+  ),
+  sendVerificationEmail: vi.fn(
+    async (_params?: unknown): Promise<AuthActionResult> => ({
+      data: {},
+      error: null,
+    }),
+  ),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(mocks.search),
+}));
+
+vi.mock("sonner", () => ({
+  toast: mocks.toast,
+  Toaster: () => null,
+}));
+
+vi.mock("@/components/ui/sonner", () => ({
+  Toaster: () => null,
+}));
+
+vi.mock("@/lib/auth/client", () => ({
+  resetPassword: (params: unknown) => mocks.resetPassword(params),
+  sendVerificationEmail: (params: unknown) => mocks.sendVerificationEmail(params),
+}));
+
+vi.mock("@/components/auth/PasswordInput", () => ({
+  PasswordInput: ({
+    id,
+    value,
+    onChange,
+    onStrengthChange,
+    disabled,
+  }: {
+    id: string;
+    value: string;
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    onStrengthChange?: (result: { isAcceptable: boolean } | null) => void;
+    disabled?: boolean;
+  }) => (
+    <input
+      id={id}
+      type="password"
+      value={value}
+      disabled={disabled}
+      onChange={(event) => {
+        onChange(event);
+        onStrengthChange?.({ isAcceptable: event.target.value.includes("Strong") });
+      }}
+    />
+  ),
+}));
+
+describe("auth action pages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.search = "";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders reset-password invalid, weak-password, success, and provider error states", async () => {
+    const user = userEvent.setup();
+
+    const invalid = render(<ResetPasswordPage />);
+    expect(screen.getByText("Invalid Reset Link")).toBeInTheDocument();
+    invalid.unmount();
+
+    mocks.search = "token=reset_123";
+    const { unmount } = render(<ResetPasswordPage />);
+    await user.type(screen.getByLabelText("New Password"), "WeakPass1!");
+    await user.type(screen.getByLabelText("Confirm Password"), "WeakPass1!");
+    fireEvent.submit(screen.getByRole("button", { name: "Reset Password" }).closest("form")!);
+    await waitFor(() =>
+      expect(mocks.toast.error).toHaveBeenCalledWith("Please choose a stronger password"),
+    );
+    unmount();
+
+    mocks.resetPassword.mockResolvedValueOnce({ data: {}, error: null });
+    render(<ResetPasswordPage />);
+    await user.type(screen.getByLabelText("New Password"), "StrongPass123!");
+    await user.type(screen.getByLabelText("Confirm Password"), "StrongPass123!");
+    fireEvent.submit(screen.getByRole("button", { name: "Reset Password" }).closest("form")!);
+    expect(await screen.findByText("Password Reset Successfully")).toBeInTheDocument();
+  });
+
+  it("maps reset-password expired, password, generic, and thrown failures", async () => {
+    const user = userEvent.setup();
+    mocks.search = "token=reset_123";
+
+    mocks.resetPassword.mockResolvedValueOnce({
+      data: null,
+      error: { message: "token expired" },
+    });
+    const expired = render(<ResetPasswordPage />);
+    await user.type(screen.getByLabelText("New Password"), "StrongPass123!");
+    await user.type(screen.getByLabelText("Confirm Password"), "StrongPass123!");
+    fireEvent.submit(screen.getByRole("button", { name: "Reset Password" }).closest("form")!);
+    await waitFor(() =>
+      expect(mocks.toast.error).toHaveBeenCalledWith(
+        "This reset link has expired. Please request a new one.",
+      ),
+    );
+    expired.unmount();
+
+    mocks.resetPassword.mockResolvedValueOnce({
+      data: null,
+      error: { message: "password is too common" },
+    });
+    const password = render(<ResetPasswordPage />);
+    await user.type(screen.getByLabelText("New Password"), "StrongPass123!");
+    await user.type(screen.getByLabelText("Confirm Password"), "StrongPass123!");
+    fireEvent.submit(screen.getByRole("button", { name: "Reset Password" }).closest("form")!);
+    await waitFor(() =>
+      expect(mocks.toast.error).toHaveBeenCalledWith("Password does not meet requirements."),
+    );
+    password.unmount();
+
+    mocks.resetPassword.mockRejectedValueOnce(new Error("network"));
+    render(<ResetPasswordPage />);
+    await user.type(screen.getByLabelText("New Password"), "StrongPass123!");
+    await user.type(screen.getByLabelText("Confirm Password"), "StrongPass123!");
+    fireEvent.submit(screen.getByRole("button", { name: "Reset Password" }).closest("form")!);
+    await waitFor(() =>
+      expect(mocks.toast.error).toHaveBeenCalledWith("Something went wrong. Please try again."),
+    );
+  });
+
+  it("renders verify-email success, error, resend success, cooldown, and failures", async () => {
+    const user = userEvent.setup();
+
+    const success = render(<VerifyEmailPage />);
+    expect(screen.getByText("Email Verified!")).toBeInTheDocument();
+    success.unmount();
+
+    mocks.search = "error=invalid_token&email=avery%40example.com";
+    const invalid = render(<VerifyEmailPage />);
+    expect(screen.getByText("Invalid Verification Link")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Resend Verification Email" }));
+    await waitFor(() =>
+      expect(mocks.toast.success).toHaveBeenCalledWith(
+        "Verification email sent! Check your inbox.",
+      ),
+    );
+    expect(screen.getByRole("button", { name: "Resend in 60s" })).toBeDisabled();
+    invalid.unmount();
+
+    mocks.search = "error=server_error";
+    const generic = render(<VerifyEmailPage />);
+    expect(screen.getByText("Verification Failed")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Resend/ })).not.toBeInTheDocument();
+    generic.unmount();
+
+    mocks.search = "error=invalid_token&email=avery%40example.com";
+    mocks.sendVerificationEmail.mockResolvedValueOnce({
+      data: null,
+      error: { message: "Rate limited" },
+    });
+    const failed = render(<VerifyEmailPage />);
+    await user.click(screen.getByRole("button", { name: "Resend Verification Email" }));
+    await waitFor(() => expect(mocks.toast.error).toHaveBeenCalledWith("Rate limited"));
+    failed.unmount();
+
+    mocks.sendVerificationEmail.mockRejectedValueOnce(new Error("network"));
+    render(<VerifyEmailPage />);
+    await user.click(screen.getByRole("button", { name: "Resend Verification Email" }));
+    await waitFor(() =>
+      expect(mocks.toast.error).toHaveBeenCalledWith("Something went wrong. Please try again."),
+    );
+  });
+});

--- a/__tests__/unit/app/auth-pages.test.tsx
+++ b/__tests__/unit/app/auth-pages.test.tsx
@@ -157,14 +157,19 @@ describe("auth action pages", () => {
     );
     password.unmount();
 
-    mocks.resetPassword.mockRejectedValueOnce(new Error("network"));
-    render(<ResetPasswordPage />);
-    await user.type(screen.getByLabelText("New Password"), "StrongPass123!");
-    await user.type(screen.getByLabelText("Confirm Password"), "StrongPass123!");
-    fireEvent.submit(screen.getByRole("button", { name: "Reset Password" }).closest("form")!);
-    await waitFor(() =>
-      expect(mocks.toast.error).toHaveBeenCalledWith("Something went wrong. Please try again."),
-    );
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      mocks.resetPassword.mockRejectedValueOnce(new Error("network"));
+      render(<ResetPasswordPage />);
+      await user.type(screen.getByLabelText("New Password"), "StrongPass123!");
+      await user.type(screen.getByLabelText("Confirm Password"), "StrongPass123!");
+      fireEvent.submit(screen.getByRole("button", { name: "Reset Password" }).closest("form")!);
+      await waitFor(() =>
+        expect(mocks.toast.error).toHaveBeenCalledWith("Something went wrong. Please try again."),
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it("renders verify-email success, error, resend success, cooldown, and failures", async () => {
@@ -202,11 +207,16 @@ describe("auth action pages", () => {
     await waitFor(() => expect(mocks.toast.error).toHaveBeenCalledWith("Rate limited"));
     failed.unmount();
 
-    mocks.sendVerificationEmail.mockRejectedValueOnce(new Error("network"));
-    render(<VerifyEmailPage />);
-    await user.click(screen.getByRole("button", { name: "Resend Verification Email" }));
-    await waitFor(() =>
-      expect(mocks.toast.error).toHaveBeenCalledWith("Something went wrong. Please try again."),
-    );
+    const errorSpy2 = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      mocks.sendVerificationEmail.mockRejectedValueOnce(new Error("network"));
+      render(<VerifyEmailPage />);
+      await user.click(screen.getByRole("button", { name: "Resend Verification Email" }));
+      await waitFor(() =>
+        expect(mocks.toast.error).toHaveBeenCalledWith("Something went wrong. Please try again."),
+      );
+    } finally {
+      errorSpy2.mockRestore();
+    }
   });
 });

--- a/__tests__/unit/app/public-pages-smoke.test.tsx
+++ b/__tests__/unit/app/public-pages-smoke.test.tsx
@@ -1,0 +1,178 @@
+import { render } from "@testing-library/react";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ProfileNotFound from "@/app/[handle]/not-found";
+import AiResumeParsingAccuracyPage, {
+  generateMetadata as generateAiResumeParsingMetadata,
+} from "@/app/blog/ai-resume-parsing-accuracy/page";
+import BestResumeWebsiteBuildersPage, {
+  generateMetadata as generateBestResumeWebsiteBuildersMetadata,
+} from "@/app/blog/best-resume-website-builders/page";
+import TemplatesShowcasePage, {
+  generateMetadata as generateTemplatesShowcaseMetadata,
+} from "@/app/blog/clickfolio-templates-showcase/page";
+import BlogLayout from "@/app/blog/layout";
+import LinkedInToPortfolioPage, {
+  generateMetadata as generateLinkedInToPortfolioMetadata,
+} from "@/app/blog/linkedin-to-portfolio/page";
+import BlogPage from "@/app/blog/page";
+import PdfResumeToWebsitePage, {
+  generateMetadata as generatePdfResumeToWebsiteMetadata,
+} from "@/app/blog/pdf-resume-to-website/page";
+import PdfResumeVsPortfolioPage, {
+  generateMetadata as generatePdfResumeVsPortfolioMetadata,
+} from "@/app/blog/pdf-resume-vs-portfolio/page";
+import PrivacyAtClickfolioPage, {
+  generateMetadata as generatePrivacyAtClickfolioMetadata,
+} from "@/app/blog/privacy-at-clickfolio/page";
+import ResumeWritingTipsPage, {
+  generateMetadata as generateResumeWritingTipsMetadata,
+} from "@/app/blog/resume-writing-tips/page";
+import ConsultantPage from "@/app/for/consultant/page";
+import DesignerPage from "@/app/for/designer/page";
+import MarketerPage from "@/app/for/marketer/page";
+import ProductManagerPage from "@/app/for/product-manager/page";
+import SoftwareEngineerPage from "@/app/for/software-engineer/page";
+import StudentPage from "@/app/for/student/page";
+import GlobalError from "@/app/global-error";
+import RootNotFound from "@/app/not-found";
+import Home from "@/app/page";
+import PrivacyPolicyPage from "@/app/privacy/page";
+import TermsOfServicePage from "@/app/terms/page";
+
+const router = {
+  push: vi.fn(),
+  replace: vi.fn(),
+  refresh: vi.fn(),
+  back: vi.fn(),
+};
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => router,
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams("ref=ABCD1234"),
+}));
+
+vi.mock("@/lib/auth/client", () => ({
+  useSession: () => ({ data: null, isPending: false }),
+  signIn: { social: vi.fn(), email: vi.fn() },
+  signUp: { email: vi.fn() },
+  signOut: vi.fn(),
+  sendVerificationEmail: vi.fn(),
+  resetPassword: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+const pages: Array<[string, React.ComponentType]> = [
+  ["blog index", BlogPage],
+  ["ai parsing post", AiResumeParsingAccuracyPage],
+  ["resume builder post", BestResumeWebsiteBuildersPage],
+  ["templates post", TemplatesShowcasePage],
+  ["linkedin post", LinkedInToPortfolioPage],
+  ["pdf resume post", PdfResumeToWebsitePage],
+  ["pdf vs portfolio post", PdfResumeVsPortfolioPage],
+  ["privacy blog post", PrivacyAtClickfolioPage],
+  ["writing tips post", ResumeWritingTipsPage],
+  ["consultant page", ConsultantPage],
+  ["designer page", DesignerPage],
+  ["marketer page", MarketerPage],
+  ["product manager page", ProductManagerPage],
+  ["software engineer page", SoftwareEngineerPage],
+  ["student page", StudentPage],
+  ["privacy page", PrivacyPolicyPage],
+  ["terms page", TermsOfServicePage],
+];
+
+describe("public page rendering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    }) as unknown as typeof fetch;
+    globalThis.IntersectionObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof IntersectionObserver;
+    Object.defineProperty(navigator, "sendBeacon", {
+      value: vi.fn(),
+      configurable: true,
+    });
+  });
+
+  it("renders the homepage with its upload CTA and discovery content", () => {
+    const { container } = render(<Home />);
+
+    expect(container.textContent).toContain("Your Resume");
+    expect(container.textContent).toContain("Drop your PDF");
+    expect(container.textContent).toContain("Open source");
+    expect(navigator.sendBeacon).toHaveBeenCalledWith(
+      "/api/referral/track",
+      JSON.stringify({ code: "ABCD1234", source: "homepage" }),
+    );
+  });
+
+  it.each(pages)("renders %s", (_name, Page) => {
+    const { container } = render(<Page />);
+    expect(container.textContent?.trim().length).toBeGreaterThan(20);
+  });
+
+  it("renders blog layout and not-found surfaces", () => {
+    expect(render(<BlogLayout>Article content</BlogLayout>).container.textContent).toContain(
+      "Article content",
+    );
+    expect(render(<RootNotFound />).container.textContent).toContain("Page Not Found");
+    expect(render(<ProfileNotFound />).container.textContent).toContain("Resume Not Found");
+  });
+
+  it("renders the global error surface", () => {
+    const { container } = render(
+      <GlobalError error={new Error("fatal render failure")} reset={vi.fn()} />,
+    );
+
+    expect(container.textContent).toContain("Something went wrong");
+  });
+
+  it("keeps blog metadata generators wired to titles", () => {
+    const metadata = [
+      generateAiResumeParsingMetadata(),
+      generateBestResumeWebsiteBuildersMetadata(),
+      generateTemplatesShowcaseMetadata(),
+      generateLinkedInToPortfolioMetadata(),
+      generatePdfResumeToWebsiteMetadata(),
+      generatePdfResumeVsPortfolioMetadata(),
+      generatePrivacyAtClickfolioMetadata(),
+      generateResumeWritingTipsMetadata(),
+    ];
+
+    const titles = metadata.map((entry) => String(entry.title)).join("\n");
+
+    expect(titles).toContain("AI Resume Parsing");
+    expect(titles).toContain("Resume Website Builders");
+    expect(titles).toContain("LinkedIn");
+  });
+});

--- a/__tests__/unit/app/public-pages-smoke.test.tsx
+++ b/__tests__/unit/app/public-pages-smoke.test.tsx
@@ -150,11 +150,16 @@ describe("public page rendering", () => {
   });
 
   it("renders the global error surface", () => {
-    const { container } = render(
-      <GlobalError error={new Error("fatal render failure")} reset={vi.fn()} />,
-    );
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { container } = render(
+        <GlobalError error={new Error("fatal render failure")} reset={vi.fn()} />,
+      );
 
-    expect(container.textContent).toContain("Something went wrong");
+      expect(container.textContent).toContain("Something went wrong");
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it("keeps blog metadata generators wired to titles", () => {

--- a/__tests__/unit/app/server-pages.test.tsx
+++ b/__tests__/unit/app/server-pages.test.tsx
@@ -1,0 +1,506 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResumeContent } from "@/lib/types/database";
+
+const mocks = vi.hoisted(() => {
+  const state = {
+    selectResults: [] as unknown[][],
+    session: {
+      user: { id: "user_1", email: "avery@example.com", name: "Avery Quinn" },
+    } as { user: { id: string; email: string; name: string } } | null,
+    dashboardMode: "published" as "published" | "empty" | "processing",
+  };
+
+  const nextSelectResult = () => state.selectResults.shift() ?? [];
+  const createChain = (): Record<string, unknown> => {
+    const chain: Record<string, unknown> = {
+      from: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      leftJoin: vi.fn(() => chain),
+      orderBy: vi.fn(() => chain),
+      groupBy: vi.fn(() => chain),
+      limit: vi.fn(() => chain),
+      offset: vi.fn(() => chain),
+      values: vi.fn(() => chain),
+      // biome-ignore lint/suspicious/noThenProperty: Drizzle query mocks must be awaitable.
+      then: vi.fn((resolve: (value: unknown[]) => unknown) => resolve(nextSelectResult())),
+    };
+    return chain;
+  };
+
+  const db = {
+    query: {
+      user: { findFirst: vi.fn() },
+      siteData: { findFirst: vi.fn() },
+      resumes: { findFirst: vi.fn() },
+    },
+    select: vi.fn(() => createChain()),
+  };
+
+  return {
+    state,
+    db,
+    env: { CLICKFOLIO_DB: {} },
+    redirect: vi.fn((url: string) => {
+      throw new Error(`redirect:${url}`);
+    }),
+    notFound: vi.fn(() => {
+      throw new Error("notFound");
+    }),
+    requireAdminAuth: vi.fn(async () => undefined),
+    getStats: vi.fn(async () => ({ pageviews: 111, visitors: 22 })),
+    getPageviews: vi.fn(async () => ({
+      pageviews: [{ x: "2026-05-20T00:00:00Z", y: 9 }],
+      sessions: [],
+    })),
+  };
+});
+
+vi.mock("cloudflare:workers", () => ({ env: mocks.env }));
+
+vi.mock("next/navigation", () => ({
+  redirect: mocks.redirect,
+  notFound: mocks.notFound,
+  usePathname: () => "/dashboard",
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  getServerSession: vi.fn(async () => mocks.state.session),
+}));
+
+vi.mock("@/lib/auth/admin", () => ({
+  requireAdminAuth: mocks.requireAdminAuth,
+}));
+
+vi.mock("@/lib/auth/client", () => ({
+  useSession: () => ({ data: mocks.state.session, isPending: false }),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getDb: vi.fn(() => mocks.db),
+}));
+
+vi.mock("@/lib/umami/client", () => ({
+  getStats: mocks.getStats,
+  getPageviews: mocks.getPageviews,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  relations: vi.fn((_table, build) =>
+    build({
+      many: vi.fn((table) => ({ relation: "many", table })),
+      one: vi.fn((table, config) => ({ relation: "one", table, config })),
+    }),
+  ),
+  eq: vi.fn((_field, value) => ({ op: "eq", value })),
+  and: vi.fn((...conditions) => ({ op: "and", conditions })),
+  or: vi.fn((...conditions) => ({ op: "or", conditions })),
+  ne: vi.fn((_field, value) => ({ op: "ne", value })),
+  desc: vi.fn((field) => ({ op: "desc", field })),
+  isNotNull: vi.fn((field) => ({ op: "isNotNull", field })),
+  count: vi.fn(() => ({ op: "count" })),
+  sql: vi.fn(() => ({ op: "sql" })),
+}));
+
+vi.mock("@/components/dashboard/AnalyticsCard", () => ({
+  AnalyticsCard: () => <div>analytics-card</div>,
+}));
+vi.mock("@/components/dashboard/CopyLinkButton", () => ({
+  CopyLinkButton: ({ handle }: { handle: string }) => <button type="button">copy {handle}</button>,
+}));
+vi.mock("@/components/dashboard/DashboardUploadSection", () => ({
+  DashboardUploadSection: ({ children }: { children?: React.ReactNode }) => (
+    <button type="button">{children || "upload-section"}</button>
+  ),
+}));
+vi.mock("@/components/dashboard/EmailVerificationBanner", () => ({
+  EmailVerificationBanner: ({ email }: { email: string }) => <div>verify {email}</div>,
+}));
+vi.mock("@/components/dashboard/RealtimeStatusListener", () => ({
+  RealtimeStatusListener: ({ currentStatus }: { currentStatus: string }) => (
+    <div>realtime {currentStatus}</div>
+  ),
+}));
+vi.mock("@/components/dashboard/ReferralStats", () => ({
+  ReferralStats: ({ referralCode }: { referralCode: string }) => <div>referral {referralCode}</div>,
+}));
+vi.mock("@/components/dashboard/ThemeSelector", () => ({
+  ThemeSelector: ({ initialThemeId }: { initialThemeId: string }) => (
+    <div>theme {initialThemeId}</div>
+  ),
+}));
+
+vi.mock("@/components/forms/EditResumeFormWrapper", () => ({
+  EditResumeFormWrapper: ({ initialData }: { initialData: ResumeContent }) => (
+    <div>edit-wrapper {initialData.full_name}</div>
+  ),
+}));
+vi.mock("@/components/forms/HandleForm", () => ({
+  HandleForm: ({ currentHandle }: { currentHandle: string }) => <div>handle {currentHandle}</div>,
+}));
+vi.mock("@/components/forms/PrivacySettings", () => ({
+  PrivacySettingsForm: () => <div>privacy-settings</div>,
+}));
+vi.mock("@/components/settings/DeleteAccountCard", () => ({
+  DeleteAccountCard: ({ userEmail }: { userEmail: string }) => <div>delete {userEmail}</div>,
+}));
+vi.mock("@/components/settings/ResumeManagementCard", () => ({
+  ResumeManagementCard: ({ resumeCount }: { resumeCount: number }) => (
+    <div>resumes {resumeCount}</div>
+  ),
+}));
+vi.mock("@/components/settings/RoleSelectorCard", () => ({
+  RoleSelectorCard: ({ currentRole }: { currentRole: string | null }) => (
+    <div>role {currentRole}</div>
+  ),
+}));
+vi.mock("@/components/admin/AdminHeader", () => ({
+  AdminHeader: ({ onMenuClick }: { onMenuClick: () => void }) => (
+    <button type="button" onClick={onMenuClick}>
+      admin-header
+    </button>
+  ),
+}));
+vi.mock("@/components/admin/AdminSidebar", () => ({
+  AdminSidebar: ({ isOpen, adminEmail }: { isOpen: boolean; adminEmail?: string }) => (
+    <div>
+      admin-sidebar {adminEmail} {isOpen ? "open" : "closed"}
+    </div>
+  ),
+}));
+vi.mock("@/components/admin/AdminSparkline", () => ({
+  AdminSparkline: ({ data }: { data: unknown[] }) => <div>sparkline {data.length}</div>,
+}));
+vi.mock("@/components/admin/StatCard", () => ({
+  StatCard: ({ title, value }: { title: string; value: string | number }) => (
+    <div>
+      {title}: {value}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/SiteHeader", () => ({ SiteHeader: () => <header>site-header</header> }));
+vi.mock("@/components/Footer", () => ({ Footer: () => <footer>footer</footer> }));
+vi.mock("@/components/ui/Breadcrumb", () => ({ Breadcrumb: () => <nav>breadcrumb</nav> }));
+vi.mock("@/components/analytics/OwnerDetector", () => ({
+  OwnerDetector: ({ profileId }: { profileId: string }) => <div>owner {profileId}</div>,
+}));
+
+vi.mock("@/lib/templates/theme-registry", () => ({
+  getTemplate: vi.fn(async () => ({ content }: { content: ResumeContent }) => (
+    <article>{content.full_name} template</article>
+  )),
+}));
+
+const resumeContent: ResumeContent = {
+  full_name: "Avery Quinn",
+  headline: "Staff Product Engineer",
+  summary: "Builds reliable products with TypeScript and Cloudflare.",
+  contact: {
+    email: "avery@example.com",
+    phone: "555-0100",
+    location: "Phoenix, AZ, USA",
+    website: "https://avery.dev",
+  },
+  experience: [
+    {
+      title: "Staff Engineer",
+      company: "Acme",
+      start_date: "2022",
+      description: "Built reliable products.",
+      highlights: [],
+    },
+  ],
+  education: [{ degree: "BS CS", institution: "State University" }],
+  skills: [{ category: "Languages", items: ["TypeScript", "SQL", "React", "Workers", "D1"] }],
+  certifications: [],
+  projects: [],
+};
+
+function siteDataRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "site_1",
+    userId: "user_1",
+    resumeId: "res_1",
+    content: JSON.stringify(resumeContent),
+    themeId: "minimalist_editorial",
+    createdAt: "2026-05-20T00:00:00Z",
+    updatedAt: "2026-05-20T00:00:00Z",
+    lastPublishedAt: "2026-05-20T00:00:00Z",
+    previewName: "Avery Quinn",
+    previewHeadline: "Staff Product Engineer",
+    previewLocation: "Phoenix, AZ",
+    previewExpCount: 1,
+    previewEduCount: 1,
+    previewSkills: JSON.stringify(["TypeScript", "SQL", "React", "Workers", "D1"]),
+    ...overrides,
+  };
+}
+
+function installDbDefaults() {
+  mocks.db.query.user.findFirst.mockImplementation(
+    async (args: { with?: Record<string, unknown>; columns?: Record<string, boolean> }) => {
+      if (args.with && "resumes" in args.with) {
+        if (mocks.state.dashboardMode === "empty") {
+          return {
+            id: "user_1",
+            handle: "avery",
+            name: "Avery Quinn",
+            email: "avery@example.com",
+            emailVerified: false,
+            image: null,
+            headline: "Engineer",
+            privacySettings: "{}",
+            onboardingCompleted: true,
+            createdAt: "2026-05-20T00:00:00Z",
+            referralCount: 0,
+            referralCode: null,
+            resumes: [],
+            siteData: null,
+            accounts: [],
+          };
+        }
+        return {
+          id: "user_1",
+          handle: "avery",
+          name: "Avery Quinn",
+          email: "avery@example.com",
+          emailVerified: false,
+          image: null,
+          headline: "Engineer",
+          privacySettings: "{}",
+          onboardingCompleted: true,
+          createdAt: "2026-05-20T00:00:00Z",
+          referralCount: 3,
+          referralCode: "REF123",
+          resumes: [
+            {
+              id: "res_1",
+              status: mocks.state.dashboardMode === "processing" ? "processing" : "failed",
+              errorMessage: "Parse failed",
+              createdAt: "2026-05-20T00:00:00Z",
+            },
+          ],
+          siteData: mocks.state.dashboardMode === "processing" ? null : siteDataRow(),
+          accounts: [{ providerId: "google" }],
+        };
+      }
+
+      if (args.columns?.isPro) {
+        return { handle: "avery", image: null, isPro: false, referralCount: 3 };
+      }
+
+      if (args.with && "siteData" in args.with) {
+        return {
+          id: "user_1",
+          name: "Avery Quinn",
+          email: "avery@example.com",
+          handle: "avery",
+          headline: "Staff Product Engineer",
+          image: null,
+          privacySettings: JSON.stringify({
+            show_phone: false,
+            show_address: false,
+            hide_from_search: false,
+            show_in_directory: true,
+          }),
+          isPro: false,
+          referralCount: 0,
+          siteData: siteDataRow(),
+        };
+      }
+
+      return {
+        id: "user_1",
+        email: "avery@example.com",
+        handle: "avery",
+        headline: "Staff Product Engineer",
+        image: null,
+        privacySettings: "{}",
+        role: "senior",
+        roleSource: "ai",
+      };
+    },
+  );
+
+  mocks.db.query.siteData.findFirst.mockResolvedValue(siteDataRow());
+  mocks.db.query.resumes.findFirst.mockResolvedValue({
+    id: "res_1",
+    createdAt: "2026-05-20T00:00:00Z",
+    status: "failed",
+    errorMessage: "Parse failed",
+  });
+}
+
+describe("server rendered app pages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.state.selectResults = [];
+    mocks.state.session = {
+      user: { id: "user_1", email: "avery@example.com", name: "Avery Quinn" },
+    };
+    mocks.state.dashboardMode = "published";
+    installDbDefaults();
+  });
+
+  it("renders protected dashboard states", async () => {
+    const { default: DashboardPage } = await import("@/app/(protected)/dashboard/page");
+
+    mocks.state.selectResults = [[{ count: 7 }]];
+    render(await DashboardPage());
+    expect(screen.getByText("Avery Quinn")).toBeInTheDocument();
+    expect(screen.getAllByText(/Parse failed/).length).toBeGreaterThan(0);
+    expect(screen.getByText("referral REF123")).toBeInTheDocument();
+
+    mocks.state.dashboardMode = "empty";
+    mocks.state.selectResults = [[{ count: 0 }]];
+    render(await DashboardPage());
+    expect(screen.getByText("No Resume Yet")).toBeInTheDocument();
+
+    mocks.state.session = null;
+    await expect(DashboardPage()).rejects.toThrow("redirect:/");
+  });
+
+  it("renders settings, edit, themes, and protected layout surfaces", async () => {
+    const { default: SettingsPage } = await import("@/app/(protected)/settings/page");
+    const { default: EditPage } = await import("@/app/(protected)/edit/page");
+    const { default: ThemesPage } = await import("@/app/(protected)/themes/page");
+    const { default: ProtectedLayout } = await import("@/app/(protected)/layout");
+    const { SidebarLayoutClient } = await import("@/app/(protected)/SidebarLayoutClient");
+
+    mocks.state.selectResults = [[{ count: 2, latestId: "res_1" }]];
+    render(await SettingsPage());
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+    expect(screen.getByText("resumes 2")).toBeInTheDocument();
+
+    render(await EditPage());
+    expect(screen.getByText("Edit Resume")).toBeInTheDocument();
+    expect(screen.getByText("edit-wrapper Avery Quinn")).toBeInTheDocument();
+
+    render(await ThemesPage());
+    expect(screen.getByText("theme minimalist_editorial")).toBeInTheDocument();
+
+    render(<ProtectedLayout>child</ProtectedLayout>);
+    expect(screen.getByText("child")).toBeInTheDocument();
+
+    render(<SidebarLayoutClient>body</SidebarLayoutClient>);
+    await userEvent.click(screen.getAllByRole("button", { name: /open navigation menu/i })[0]);
+    expect(document.body.style.overflow).toBe("hidden");
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await waitFor(() => expect(document.body.style.overflow).toBe("unset"));
+  });
+
+  it("renders explore directory with filters and pagination", async () => {
+    const { default: ExplorePage } = await import("@/app/explore/page");
+    mocks.state.selectResults = [
+      [{ count: 13 }],
+      [
+        {
+          handle: "avery",
+          role: "senior",
+          previewName: "Avery Quinn",
+          previewHeadline: "Engineer",
+          previewLocation: "Phoenix, AZ",
+          previewExpCount: 1,
+          previewEduCount: 1,
+          previewSkills: JSON.stringify(["TypeScript", "SQL", "React", "Workers", "D1"]),
+        },
+      ],
+    ];
+
+    render(await ExplorePage({ searchParams: Promise.resolve({ page: "2", role: "senior" }) }));
+    expect(screen.getByText("Explore Professionals")).toBeInTheDocument();
+    expect(screen.getByText("Avery Quinn")).toBeInTheDocument();
+    expect(screen.getByText("+1 more")).toBeInTheDocument();
+    expect(screen.getByText("Previous")).toBeInTheDocument();
+  });
+
+  it("renders public handle page, metadata, and preview page", async () => {
+    mocks.db.query.user.findFirst.mockResolvedValue({
+      id: "user_1",
+      name: "Avery Quinn",
+      email: "avery@example.com",
+      handle: "avery",
+      headline: "Staff Product Engineer",
+      image: null,
+      privacySettings: JSON.stringify({
+        show_phone: false,
+        show_address: false,
+        hide_from_search: false,
+        show_in_directory: true,
+      }),
+      isPro: false,
+      referralCount: 0,
+      siteData: siteDataRow(),
+    });
+    const handlePage = await import("@/app/[handle]/page");
+    mocks.state.selectResults = [[{ handle: "casey", name: "Casey", headline: "Designer" }]];
+
+    const metadata = await handlePage.generateMetadata({
+      params: Promise.resolve({ handle: "%40avery" }),
+    });
+    expect(metadata.title).toContain("Avery Quinn");
+
+    render(await handlePage.default({ params: Promise.resolve({ handle: "%40avery" }) }));
+    expect(screen.getByText("Avery Quinn template")).toBeInTheDocument();
+    expect(screen.getByText("breadcrumb")).toBeInTheDocument();
+    expect(screen.getByText(/owner user_1/)).toBeInTheDocument();
+
+    await expect(
+      handlePage.default({ params: Promise.resolve({ handle: "avery" }) }),
+    ).rejects.toThrow("notFound");
+
+    const { default: PreviewPage } = await import("@/app/preview/[id]/page");
+    render(await PreviewPage({ params: Promise.resolve({ id: "classic_ats" }) }));
+    expect(screen.getAllByText(/template/).length).toBeGreaterThan(1);
+  });
+
+  it("renders admin overview and admin layout", async () => {
+    const { default: AdminOverviewPage } = await import("@/app/(admin)/admin/page");
+    const { default: AdminLayout } = await import("@/app/(admin)/admin/layout");
+    const { AdminLayoutClient } = await import("@/app/(admin)/admin/layout-client");
+
+    mocks.state.selectResults = [
+      [{ count: 10 }],
+      [{ count: 6 }],
+      [
+        { status: "processing", count: 2 },
+        { status: "queued", count: 1 },
+        { status: "failed", count: 2 },
+      ],
+      [{ email: "new@example.com", name: "New User", createdAt: new Date().toISOString() }],
+    ];
+
+    render(await AdminOverviewPage());
+    expect(screen.getByText("Total Users: 10")).toBeInTheDocument();
+    expect(screen.getByText("Processing: 3")).toBeInTheDocument();
+    expect(screen.getByText(/2 Failed Resumes/)).toBeInTheDocument();
+    expect(screen.getByText("New User")).toBeInTheDocument();
+
+    render(await AdminLayout({ children: <div>admin-child</div> }));
+    expect(screen.getByText("admin-child")).toBeInTheDocument();
+
+    render(<AdminLayoutClient>admin-body</AdminLayoutClient>);
+    await userEvent.click(screen.getAllByRole("button", { name: "admin-header" })[0]);
+    expect(screen.getByText(/open/)).toBeInTheDocument();
+  });
+});

--- a/__tests__/unit/app/server-pages.test.tsx
+++ b/__tests__/unit/app/server-pages.test.tsx
@@ -258,7 +258,7 @@ function siteDataRow(overrides: Record<string, unknown> = {}) {
 
 function installDbDefaults() {
   mocks.db.query.user.findFirst.mockImplementation(
-    async (args: { with?: Record<string, unknown>; columns?: Record<string, boolean> }) => {
+    async (args: { with?: Record<string, unknown>; columns?: Record<string, boolean> } = {}) => {
       if (args.with && "resumes" in args.with) {
         if (mocks.state.dashboardMode === "empty") {
           return {

--- a/__tests__/unit/app/waiting-page.test.tsx
+++ b/__tests__/unit/app/waiting-page.test.tsx
@@ -1,0 +1,127 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import WaitingPage from "@/app/(protected)/waiting/page";
+
+const mocks = vi.hoisted(() => ({
+  router: {
+    push: vi.fn(),
+  },
+  searchParams: "resume_id=res_123",
+  resumeStatus: {
+    status: "processing" as "processing" | "completed" | "failed" | null,
+    progress: 55,
+    error: null as string | null,
+    canRetry: false,
+    isLoading: false,
+    refetch: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => mocks.router,
+  useSearchParams: () => new URLSearchParams(mocks.searchParams),
+}));
+
+vi.mock("@/hooks/useResumeStatus", () => ({
+  useResumeStatus: vi.fn(() => mocks.resumeStatus),
+}));
+
+describe("WaitingPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.searchParams = "resume_id=res_123";
+    mocks.resumeStatus.status = "processing";
+    mocks.resumeStatus.progress = 55;
+    mocks.resumeStatus.error = null;
+    mocks.resumeStatus.canRetry = false;
+    mocks.resumeStatus.isLoading = false;
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+    globalThis.alert = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("redirects to dashboard when no resume id is present", async () => {
+    mocks.searchParams = "";
+    const { container } = render(<WaitingPage />);
+
+    await waitFor(() => expect(mocks.router.push).toHaveBeenCalledWith("/dashboard"));
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders processing stages, countdown, loading, and inline processing errors", async () => {
+    vi.useFakeTimers();
+    mocks.resumeStatus.status = null;
+    mocks.resumeStatus.isLoading = true;
+    const loading = render(<WaitingPage />);
+    expect(screen.getByText("Connecting...")).toBeInTheDocument();
+    loading.unmount();
+
+    mocks.resumeStatus.status = "processing";
+    mocks.resumeStatus.isLoading = false;
+    mocks.resumeStatus.progress = 55;
+    mocks.resumeStatus.error = "Still processing";
+    render(<WaitingPage />);
+
+    expect(screen.getByText("Processing your resume with AI")).toBeInTheDocument();
+    expect(screen.getByText("55% complete")).toBeInTheDocument();
+    expect(screen.getByText("Analyzing Experience")).toBeInTheDocument();
+    expect(screen.getByText("Still processing")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.getByText("~34 seconds remaining")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(35_000);
+    });
+    expect(screen.getByText("Almost there...")).toBeInTheDocument();
+  });
+
+  it("redirects completed resumes to the wizard after the success message", async () => {
+    vi.useFakeTimers();
+    mocks.resumeStatus.status = "completed";
+    render(<WaitingPage />);
+
+    expect(screen.getByText("Parsing Complete!")).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(mocks.router.push).toHaveBeenCalledWith("/wizard");
+  });
+
+  it("retries failed resumes and reports retry API failures", async () => {
+    mocks.resumeStatus.status = "failed";
+    mocks.resumeStatus.error = null;
+    mocks.resumeStatus.canRetry = true;
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(Response.json({ success: true }))
+      .mockResolvedValueOnce(Response.json({ error: "Queue unavailable" }, { status: 500 }));
+
+    const { rerender } = render(<WaitingPage />);
+
+    expect(screen.getByText("Unknown error occurred")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Try Again" }));
+
+    await waitFor(() => expect(mocks.resumeStatus.refetch).toHaveBeenCalled());
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/resume/retry",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ resume_id: "res_123" }),
+      }),
+    );
+
+    mocks.resumeStatus.error = "Parse failed";
+    rerender(<WaitingPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Try Again" }));
+
+    await waitFor(() => expect(globalThis.alert).toHaveBeenCalledWith("Queue unavailable"));
+    fireEvent.click(screen.getByRole("button", { name: "Go to Dashboard" }));
+    expect(mocks.router.push).toHaveBeenCalledWith("/dashboard");
+  });
+});

--- a/__tests__/unit/app/waiting-page.test.tsx
+++ b/__tests__/unit/app/waiting-page.test.tsx
@@ -28,6 +28,9 @@ vi.mock("@/hooks/useResumeStatus", () => ({
 }));
 
 describe("WaitingPage", () => {
+  const originalFetch = globalThis.fetch;
+  const originalAlert = globalThis.alert;
+
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.searchParams = "resume_id=res_123";
@@ -42,6 +45,8 @@ describe("WaitingPage", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    globalThis.fetch = originalFetch;
+    globalThis.alert = originalAlert;
   });
 
   it("redirects to dashboard when no resume id is present", async () => {

--- a/__tests__/unit/app/wizard-page-flow.test.tsx
+++ b/__tests__/unit/app/wizard-page-flow.test.tsx
@@ -349,45 +349,54 @@ describe("wizard page flow", () => {
   });
 
   it("uses sessionStorage fallback, handles parsing failure redirects, and reports init crashes", async () => {
-    const { default: WizardPage } = await import("@/app/(protected)/wizard/page");
-    sessionStorage.setItem(
-      "temp_upload",
-      JSON.stringify({
-        key: "temp/session.pdf",
-        timestamp: Date.now(),
-        expiresAt: Date.now() + 30_000,
-      }),
-    );
-    sessionStorage.setItem("temp_file_hash", "hash_1");
-    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url === "/api/upload/pending") {
-        throw new Error("cookie unavailable");
-      }
-      if (url === "/api/resume/claim") {
-        return Response.json({ resume_id: "res_session", cached: false });
-      }
-      return Response.json(null);
-    }) as unknown as typeof fetch;
-    mocks.waitForResumeCompletion.mockResolvedValueOnce({
-      status: "failed",
-      error: "Parser failed",
-    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { default: WizardPage } = await import("@/app/(protected)/wizard/page");
+      sessionStorage.setItem(
+        "temp_upload",
+        JSON.stringify({
+          key: "temp/session.pdf",
+          timestamp: Date.now(),
+          expiresAt: Date.now() + 30_000,
+        }),
+      );
+      sessionStorage.setItem("temp_file_hash", "hash_1");
+      globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "/api/upload/pending") {
+          throw new Error("cookie unavailable");
+        }
+        if (url === "/api/resume/claim") {
+          return Response.json({ resume_id: "res_session", cached: false });
+        }
+        return Response.json(null);
+      }) as unknown as typeof fetch;
+      mocks.waitForResumeCompletion.mockResolvedValueOnce({
+        status: "failed",
+        error: "Parser failed",
+      });
 
-    const failed = render(<WizardPage />);
-    await waitFor(() => expect(mocks.waitForResumeCompletion).toHaveBeenCalledWith("res_session"));
-    failed.unmount();
+      const failed = render(<WizardPage />);
+      await waitFor(() =>
+        expect(mocks.waitForResumeCompletion).toHaveBeenCalledWith("res_session"),
+      );
+      failed.unmount();
 
-    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
-      if (String(input) === "/api/site-data") {
-        throw new Error("site-data down");
-      }
-      return Response.json({ key: null, file_hash: null });
-    }) as unknown as typeof fetch;
-    render(<WizardPage />);
-    await waitFor(() =>
-      expect(screen.getByText("Failed to load resume data. Please try again.")).toBeInTheDocument(),
-    );
+      globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input) === "/api/site-data") {
+          throw new Error("site-data down");
+        }
+        return Response.json({ key: null, file_hash: null });
+      }) as unknown as typeof fetch;
+      render(<WizardPage />);
+      await waitFor(() =>
+        expect(
+          screen.getByText("Failed to load resume data. Please try again."),
+        ).toBeInTheDocument(),
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it("cleans expired and invalid fallback uploads and warns before abandoning later steps", async () => {

--- a/__tests__/unit/app/wizard-page-flow.test.tsx
+++ b/__tests__/unit/app/wizard-page-flow.test.tsx
@@ -1,0 +1,416 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResumeContent } from "@/lib/types/database";
+
+const mocks = vi.hoisted(() => ({
+  router: { push: vi.fn() },
+  toast: { error: vi.fn(), success: vi.fn() },
+  sessionState: {
+    current: {
+      data: { user: { id: "user_1", email: "avery@example.com", name: "Avery" } },
+      isPending: false,
+    } as {
+      data: {
+        user: { id: string; email: string; name: string; onboardingCompleted?: boolean };
+      } | null;
+      isPending: boolean;
+    },
+  },
+  clearPendingUploadCookie: vi.fn(async () => undefined),
+  waitForResumeCompletion: vi.fn(
+    async (_resumeId: string): Promise<{ status: "completed" | "failed"; error?: string }> => ({
+      status: "completed",
+    }),
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => mocks.router,
+}));
+
+vi.mock("sonner", () => ({
+  toast: mocks.toast,
+}));
+
+vi.mock("@/lib/auth/client", () => ({
+  useSession: () => mocks.sessionState.current,
+}));
+
+vi.mock("@/lib/utils/pending-upload-client", () => ({
+  clearPendingUploadCookie: () => mocks.clearPendingUploadCookie(),
+}));
+
+vi.mock("@/lib/utils/wait-for-completion", () => ({
+  waitForResumeCompletion: (resumeId: string) => mocks.waitForResumeCompletion(resumeId),
+}));
+
+vi.mock("@/components/Confetti", () => ({ Confetti: () => <div>confetti</div> }));
+vi.mock("@/components/YouAreLiveModal", () => ({
+  YouAreLiveModal: ({
+    open,
+    handle,
+    onOpenChange,
+  }: {
+    open: boolean;
+    handle: string;
+    onOpenChange: (open: boolean) => void;
+  }) =>
+    open ? (
+      <button type="button" onClick={() => onOpenChange(false)}>
+        live {handle}
+      </button>
+    ) : null,
+}));
+
+vi.mock("@/components/wizard", () => ({
+  WizardProgress: ({ currentStep, totalSteps }: { currentStep: number; totalSteps: number }) => (
+    <div>
+      progress {currentStep}/{totalSteps}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/wizard/UploadStep", () => ({
+  UploadStep: ({ onContinue }: { onContinue: (content: ResumeContent) => void }) => (
+    <button type="button" onClick={() => onContinue(resumeContent)}>
+      upload-step
+    </button>
+  ),
+}));
+
+vi.mock("@/components/wizard/HandleStep", () => ({
+  HandleStep: ({
+    onContinue,
+    initialHandle,
+  }: {
+    onContinue: (handle: string) => void;
+    initialHandle: string;
+  }) => (
+    <button type="button" onClick={() => onContinue(initialHandle || "avery")}>
+      handle-step
+    </button>
+  ),
+}));
+
+vi.mock("@/components/wizard/ReviewStep", () => ({
+  ReviewStep: ({ content, onContinue }: { content: ResumeContent; onContinue: () => void }) => (
+    <button type="button" onClick={onContinue}>
+      review-step {content.full_name}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/wizard/PrivacyStep", () => ({
+  PrivacyStep: ({
+    onContinue,
+  }: {
+    onContinue: (settings: {
+      show_phone: boolean;
+      show_address: boolean;
+      show_in_directory: boolean;
+      hide_from_search: boolean;
+    }) => void;
+  }) => (
+    <button
+      type="button"
+      onClick={() =>
+        onContinue({
+          show_phone: true,
+          show_address: false,
+          show_in_directory: true,
+          hide_from_search: false,
+        })
+      }
+    >
+      privacy-step
+    </button>
+  ),
+}));
+
+vi.mock("@/components/wizard/ThemeStep", () => ({
+  ThemeStep: ({
+    onContinue,
+    referralCount,
+    isPro,
+  }: {
+    onContinue: (themeId: string) => void;
+    referralCount: number;
+    isPro: boolean;
+  }) => (
+    <button type="button" onClick={() => onContinue("minimalist_editorial")}>
+      theme-step {referralCount} {String(isPro)}
+    </button>
+  ),
+}));
+
+const resumeContent: ResumeContent = {
+  full_name: "Avery Quinn",
+  headline: "Staff Product Engineer",
+  summary: "Builds reliable products.",
+  contact: { email: "avery@example.com" },
+  experience: [],
+  education: [],
+  skills: [],
+  certifications: [],
+  projects: [],
+};
+
+type FetchScenario =
+  | "site-data"
+  | "needs-upload"
+  | "processing"
+  | "pending-claim"
+  | "complete-error";
+
+function installFetchScenario(scenario: FetchScenario) {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url === "/api/upload/pending") {
+      return Response.json(
+        scenario === "pending-claim"
+          ? { key: "temp/resume.pdf", file_hash: "hash_1" }
+          : { key: null, file_hash: null },
+      );
+    }
+    if (url === "/api/resume/claim") {
+      expect(init?.body).toContain("temp/resume.pdf");
+      return Response.json({ resume_id: "res_1", cached: scenario === "pending-claim" });
+    }
+    if (url === "/api/site-data") {
+      return Response.json(
+        scenario === "needs-upload" || scenario === "processing"
+          ? null
+          : { content: resumeContent },
+      );
+    }
+    if (url === "/api/user/stats") {
+      return Response.json({ referralCount: 4, isPro: true });
+    }
+    if (url === "/api/resume/latest-status") {
+      return Response.json(
+        scenario === "processing" ? { id: "res_processing", status: "processing" } : null,
+      );
+    }
+    if (url === "/api/wizard/complete") {
+      return Response.json(
+        scenario === "complete-error" ? { error: "Handle taken" } : { success: true },
+        { status: scenario === "complete-error" ? 400 : 200 },
+      );
+    }
+    return Response.json({ ok: true });
+  }) as unknown as typeof fetch;
+}
+
+describe("wizard page flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    mocks.sessionState.current = {
+      data: { user: { id: "user_1", email: "avery@example.com", name: "Avery" } },
+      isPending: false,
+    };
+    mocks.waitForResumeCompletion.mockResolvedValue({ status: "completed" });
+    installFetchScenario("site-data");
+  });
+
+  it("shows loading while session state is pending and redirects unauthenticated users", async () => {
+    const { default: WizardPage } = await import("@/app/(protected)/wizard/page");
+
+    mocks.sessionState.current = { data: null, isPending: true };
+    const { rerender } = render(<WizardPage />);
+    expect(screen.getByText("Loading your resume...")).toBeInTheDocument();
+
+    mocks.sessionState.current = { data: null, isPending: false };
+    rerender(<WizardPage />);
+    await waitFor(() => expect(mocks.router.push).toHaveBeenCalledWith("/"));
+  });
+
+  it("walks through site-data backed onboarding and opens the live modal", async () => {
+    const { default: WizardPage } = await import("@/app/(protected)/wizard/page");
+    render(<WizardPage />);
+
+    await waitFor(() => expect(screen.getByText("handle-step")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByText("handle-step"));
+    expect(screen.getByText(/review-step Avery Quinn/)).toBeInTheDocument();
+    await userEvent.click(screen.getByText(/review-step/));
+    await userEvent.click(screen.getByText("privacy-step"));
+    expect(screen.getByText(/theme-step/)).toHaveTextContent("4 true");
+    await userEvent.click(screen.getByText(/theme-step/));
+
+    await waitFor(() => expect(screen.getByText("confetti")).toBeInTheDocument());
+    expect(screen.getByText("live avery")).toBeInTheDocument();
+    await userEvent.click(screen.getByText("live avery"));
+    expect(mocks.router.push).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("claims pending uploads before loading site data", async () => {
+    installFetchScenario("pending-claim");
+    const { default: WizardPage } = await import("@/app/(protected)/wizard/page");
+
+    render(<WizardPage />);
+
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith("/api/resume/claim", expect.any(Object)),
+    );
+    expect(mocks.clearPendingUploadCookie).toHaveBeenCalled();
+    expect(screen.getByText("handle-step")).toBeInTheDocument();
+  });
+
+  it("routes users to waiting or upload states when site data is absent", async () => {
+    const { default: WizardPage } = await import("@/app/(protected)/wizard/page");
+
+    installFetchScenario("processing");
+    const { unmount } = render(<WizardPage />);
+    await waitFor(() =>
+      expect(mocks.router.push).toHaveBeenCalledWith("/waiting?resume_id=res_processing"),
+    );
+    unmount();
+
+    installFetchScenario("needs-upload");
+    render(<WizardPage />);
+    await waitFor(() => expect(screen.getByText("upload-step")).toBeInTheDocument());
+    await userEvent.click(screen.getByText("upload-step"));
+    expect(screen.getByText("handle-step")).toBeInTheDocument();
+  });
+
+  it("surfaces wizard completion API errors inline", async () => {
+    installFetchScenario("complete-error");
+    const { default: WizardPage } = await import("@/app/(protected)/wizard/page");
+    render(<WizardPage />);
+
+    await waitFor(() => expect(screen.getByText("handle-step")).toBeInTheDocument());
+    await userEvent.click(screen.getByText("handle-step"));
+    await userEvent.click(screen.getByText(/review-step/));
+    await userEvent.click(screen.getByText("privacy-step"));
+    await userEvent.click(screen.getByText(/theme-step/));
+
+    await waitFor(() => expect(mocks.toast.error).toHaveBeenCalledWith("Handle taken"));
+    expect(screen.getByText("Handle taken")).toBeInTheDocument();
+  });
+
+  it("claims pending uploads for returning users and always redirects to dashboard", async () => {
+    const { default: WizardPage } = await import("@/app/(protected)/wizard/page");
+    mocks.sessionState.current = {
+      data: {
+        user: {
+          id: "user_1",
+          email: "avery@example.com",
+          name: "Avery",
+          onboardingCompleted: true,
+        },
+      },
+      isPending: false,
+    };
+
+    installFetchScenario("pending-claim");
+    const cached = render(<WizardPage />);
+    await waitFor(() =>
+      expect(mocks.toast.success).toHaveBeenCalledWith("Resume updated successfully!"),
+    );
+    expect(mocks.router.push).toHaveBeenCalledWith("/dashboard");
+    cached.unmount();
+
+    vi.clearAllMocks();
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/upload/pending") {
+        return Response.json({ key: "temp/new.pdf", file_hash: null });
+      }
+      if (url === "/api/resume/claim") {
+        return Response.json({ resume_id: "res_new", cached: false });
+      }
+      return Response.json(null);
+    }) as unknown as typeof fetch;
+    const processing = render(<WizardPage />);
+    await waitFor(() =>
+      expect(mocks.toast.success).toHaveBeenCalledWith(
+        "Resume uploaded! Processing in background.",
+      ),
+    );
+    expect(mocks.router.push).toHaveBeenCalledWith("/dashboard");
+    processing.unmount();
+
+    vi.clearAllMocks();
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/upload/pending") {
+        return Response.json({ key: "temp/bad.pdf", file_hash: null });
+      }
+      if (url === "/api/resume/claim") {
+        return Response.json({ error: "Claim failed" }, { status: 400 });
+      }
+      return Response.json(null);
+    }) as unknown as typeof fetch;
+    render(<WizardPage />);
+    await waitFor(() => expect(mocks.toast.error).toHaveBeenCalledWith("Claim failed"));
+    expect(mocks.router.push).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("uses sessionStorage fallback, handles parsing failure redirects, and reports init crashes", async () => {
+    const { default: WizardPage } = await import("@/app/(protected)/wizard/page");
+    sessionStorage.setItem(
+      "temp_upload",
+      JSON.stringify({
+        key: "temp/session.pdf",
+        timestamp: Date.now(),
+        expiresAt: Date.now() + 30_000,
+      }),
+    );
+    sessionStorage.setItem("temp_file_hash", "hash_1");
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/upload/pending") {
+        throw new Error("cookie unavailable");
+      }
+      if (url === "/api/resume/claim") {
+        return Response.json({ resume_id: "res_session", cached: false });
+      }
+      return Response.json(null);
+    }) as unknown as typeof fetch;
+    mocks.waitForResumeCompletion.mockResolvedValueOnce({
+      status: "failed",
+      error: "Parser failed",
+    });
+
+    const failed = render(<WizardPage />);
+    await waitFor(() => expect(mocks.waitForResumeCompletion).toHaveBeenCalledWith("res_session"));
+    failed.unmount();
+
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input) === "/api/site-data") {
+        throw new Error("site-data down");
+      }
+      return Response.json({ key: null, file_hash: null });
+    }) as unknown as typeof fetch;
+    render(<WizardPage />);
+    await waitFor(() =>
+      expect(screen.getByText("Failed to load resume data. Please try again.")).toBeInTheDocument(),
+    );
+  });
+
+  it("cleans expired and invalid fallback uploads and warns before abandoning later steps", async () => {
+    const { default: WizardPage } = await import("@/app/(protected)/wizard/page");
+
+    sessionStorage.setItem("temp_upload", "not-json");
+    installFetchScenario("site-data");
+    const invalid = render(<WizardPage />);
+    await waitFor(() => expect(sessionStorage.getItem("temp_upload")).toBeNull());
+    invalid.unmount();
+
+    sessionStorage.setItem(
+      "temp_upload",
+      JSON.stringify({ key: "temp/expired.pdf", timestamp: 1, expiresAt: Date.now() - 1 }),
+    );
+    const expired = render(<WizardPage />);
+    await waitFor(() => expect(sessionStorage.getItem("temp_upload")).toBeNull());
+    await waitFor(() => expect(screen.getByText("handle-step")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByText("handle-step"));
+    const event = new Event("beforeunload", { cancelable: true });
+    fireEvent(window, event);
+    expect(event.defaultPrevented).toBe(true);
+    expired.unmount();
+  });
+});

--- a/__tests__/unit/app/wizard-page-flow.test.tsx
+++ b/__tests__/unit/app/wizard-page-flow.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResumeContent } from "@/lib/types/database";
 
 const mocks = vi.hoisted(() => ({
@@ -203,6 +203,8 @@ function installFetchScenario(scenario: FetchScenario) {
 }
 
 describe("wizard page flow", () => {
+  const originalFetch = globalThis.fetch;
+
   beforeEach(() => {
     vi.clearAllMocks();
     sessionStorage.clear();
@@ -212,6 +214,10 @@ describe("wizard page flow", () => {
     };
     mocks.waitForResumeCompletion.mockResolvedValue({ status: "completed" });
     installFetchScenario("site-data");
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
   });
 
   it("shows loading while session state is pending and redirects unauthenticated users", async () => {

--- a/__tests__/unit/app/wizard-page-flow.test.tsx
+++ b/__tests__/unit/app/wizard-page-flow.test.tsx
@@ -388,12 +388,13 @@ describe("wizard page flow", () => {
         }
         return Response.json({ key: null, file_hash: null });
       }) as unknown as typeof fetch;
-      render(<WizardPage />);
+      const loader = render(<WizardPage />);
       await waitFor(() =>
         expect(
           screen.getByText("Failed to load resume data. Please try again."),
         ).toBeInTheDocument(),
       );
+      loader.unmount();
     } finally {
       errorSpy.mockRestore();
     }

--- a/__tests__/unit/components/analytics-card.test.tsx
+++ b/__tests__/unit/components/analytics-card.test.tsx
@@ -102,12 +102,12 @@ describe("AnalyticsCard", () => {
 
   afterEach(() => {
     if (originalResizeObserver === undefined) {
-      delete (globalThis as any).ResizeObserver;
+      delete (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver;
     } else {
       globalThis.ResizeObserver = originalResizeObserver;
     }
     if (originalFetch === undefined) {
-      delete (globalThis as any).fetch;
+      delete (globalThis as { fetch?: typeof fetch }).fetch;
     } else {
       globalThis.fetch = originalFetch;
     }

--- a/__tests__/unit/components/analytics-card.test.tsx
+++ b/__tests__/unit/components/analytics-card.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AnalyticsCard } from "@/components/dashboard/AnalyticsCard";
 
 const chartEvents = vi.hoisted(() => ({
@@ -50,6 +50,9 @@ vi.mock("@/components/dashboard/MilestoneToasts", () => ({
   ),
 }));
 
+const originalResizeObserver = globalThis.ResizeObserver;
+const originalFetch = globalThis.fetch;
+
 function installResizeObserver(width = 420) {
   globalThis.ResizeObserver = class {
     callback: ResizeObserverCallback;
@@ -95,6 +98,19 @@ describe("AnalyticsCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     installResizeObserver();
+  });
+
+  afterEach(() => {
+    if (originalResizeObserver === undefined) {
+      delete (globalThis as any).ResizeObserver;
+    } else {
+      globalThis.ResizeObserver = originalResizeObserver;
+    }
+    if (originalFetch === undefined) {
+      delete (globalThis as any).fetch;
+    } else {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   it("renders loaded analytics, formats large numbers, and refetches selected periods", async () => {

--- a/__tests__/unit/components/analytics-card.test.tsx
+++ b/__tests__/unit/components/analytics-card.test.tsx
@@ -1,0 +1,164 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AnalyticsCard } from "@/components/dashboard/AnalyticsCard";
+
+const chartEvents = vi.hoisted(() => ({
+  destroyed: vi.fn(),
+}));
+
+vi.mock("uplot", () => {
+  class MockUPlot {
+    static paths = { spline: () => undefined };
+    over = document.createElement("div");
+    ctx = {
+      createLinearGradient: () => ({
+        addColorStop: vi.fn(),
+      }),
+    };
+    bbox = { height: 160 };
+    cursor = { idx: null as number | null, left: 320, top: 30 };
+    data: unknown[];
+
+    constructor(
+      opts: { plugins?: Array<{ hooks?: Record<string, (u: MockUPlot) => void> }> },
+      data: unknown[],
+      el: HTMLElement,
+    ) {
+      this.data = data;
+      el.appendChild(this.over);
+      for (const plugin of opts.plugins ?? []) {
+        plugin.hooks?.init?.(this);
+        plugin.hooks?.setCursor?.(this);
+        this.cursor.idx = 0;
+        plugin.hooks?.setCursor?.(this);
+        this.cursor.idx = 99;
+        plugin.hooks?.setCursor?.(this);
+      }
+    }
+
+    destroy() {
+      chartEvents.destroyed();
+    }
+  }
+
+  return { default: MockUPlot };
+});
+
+vi.mock("@/components/dashboard/MilestoneToasts", () => ({
+  MilestoneToasts: ({ totalViews }: { totalViews: number }) => (
+    <div data-testid="milestone">{totalViews}</div>
+  ),
+}));
+
+function installResizeObserver(width = 420) {
+  globalThis.ResizeObserver = class {
+    callback: ResizeObserverCallback;
+
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback;
+    }
+
+    observe(target: Element) {
+      this.callback([{ target, contentRect: { width, height: 160 } } as ResizeObserverEntry], this);
+    }
+
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+
+const baseStats = {
+  totalViews: 1500,
+  uniqueVisitors: 42,
+  viewsByDay: [
+    { date: "2026-05-18", views: 1, uniques: 1 },
+    { date: "2026-05-19", views: 4, uniques: 2 },
+  ],
+  topReferrers: [
+    { referrer: "linkedin.com", count: 6 },
+    { referrer: "google.com", count: 5 },
+    { referrer: "x.com", count: 4 },
+    { referrer: "hidden.example", count: 3 },
+  ],
+  directVisits: 9,
+  deviceBreakdown: [
+    { device: "desktop", count: 8 },
+    { device: "mobile", count: 7 },
+    { device: "tablet", count: 6 },
+    { device: "console", count: 5 },
+  ],
+  countryBreakdown: [{ country: "US", count: 12 }],
+  period: "7d",
+};
+
+describe("AnalyticsCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    installResizeObserver();
+  });
+
+  it("renders loaded analytics, formats large numbers, and refetches selected periods", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json(baseStats))
+      .mockResolvedValueOnce(
+        Response.json({ ...baseStats, totalViews: 24, period: "30d" }),
+      ) as unknown as typeof fetch;
+
+    render(<AnalyticsCard />);
+
+    expect(await screen.findByText("1.5k")).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.getByText("Direct")).toBeInTheDocument();
+    expect(screen.getByText("linkedin.com")).toBeInTheDocument();
+    expect(screen.queryByText("hidden.example")).not.toBeInTheDocument();
+    expect(screen.getByText("console")).toBeInTheDocument();
+    expect(screen.getByTestId("milestone")).toHaveTextContent("1500");
+
+    fireEvent.click(screen.getByRole("button", { name: "30d" }));
+
+    await waitFor(() =>
+      expect(globalThis.fetch).toHaveBeenLastCalledWith("/api/analytics/stats?period=30d"),
+    );
+    await waitFor(() => expect(screen.getAllByText("24").length).toBeGreaterThan(0));
+  });
+
+  it("renders loading, error, empty, and no-source states", async () => {
+    let resolveStats: (value: Response) => void = () => undefined;
+    globalThis.fetch = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveStats = resolve;
+        }),
+    ) as unknown as typeof fetch;
+
+    const { unmount } = render(<AnalyticsCard />);
+    expect(document.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+    resolveStats(new Response("broken", { status: 503 }));
+
+    expect(
+      await screen.findByText("Failed to load analytics. Try refreshing."),
+    ).toBeInTheDocument();
+    unmount();
+
+    globalThis.fetch = vi.fn(async () =>
+      Response.json({ ...baseStats, totalViews: 0, directVisits: 0, topReferrers: [] }),
+    ) as unknown as typeof fetch;
+    const empty = render(<AnalyticsCard />);
+    expect(await screen.findByText("No views yet")).toBeInTheDocument();
+    empty.unmount();
+
+    globalThis.fetch = vi.fn(async () =>
+      Response.json({
+        ...baseStats,
+        uniqueVisitors: null,
+        directVisits: 0,
+        topReferrers: [],
+        deviceBreakdown: [],
+      }),
+    ) as unknown as typeof fetch;
+    render(<AnalyticsCard />);
+    expect(await screen.findByText("No traffic sources yet")).toBeInTheDocument();
+    expect(screen.getByText("0")).toBeInTheDocument();
+  });
+});

--- a/__tests__/unit/components/auth-forms.test.tsx
+++ b/__tests__/unit/components/auth-forms.test.tsx
@@ -92,7 +92,11 @@ describe("auth form flows", () => {
   });
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    if (originalFetch === undefined) {
+      delete (globalThis as any).fetch;
+    } else {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   it("blocks sign up when disposable email validation returns a reason", async () => {

--- a/__tests__/unit/components/auth-forms.test.tsx
+++ b/__tests__/unit/components/auth-forms.test.tsx
@@ -1,0 +1,207 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ForgotPasswordForm } from "@/components/auth/ForgotPasswordForm";
+import { SignInForm } from "@/components/auth/SignInForm";
+import { SignUpForm } from "@/components/auth/SignUpForm";
+
+const mocks = vi.hoisted(() => ({
+  router: { push: vi.fn() },
+  toast: { error: vi.fn(), success: vi.fn() },
+  signUpEmail: vi.fn(),
+  signInEmail: vi.fn(),
+  requestPasswordReset: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => mocks.router,
+}));
+
+vi.mock("sonner", () => ({
+  toast: mocks.toast,
+}));
+
+vi.mock("@/lib/auth/client", () => ({
+  signUp: {
+    email: (...args: unknown[]) => mocks.signUpEmail(...args),
+  },
+  signIn: {
+    email: (...args: unknown[]) => mocks.signInEmail(...args),
+  },
+  requestPasswordReset: (...args: unknown[]) => mocks.requestPasswordReset(...args),
+}));
+
+vi.mock("@/components/auth/PasswordInput", () => ({
+  PasswordInput: ({
+    id,
+    placeholder,
+    value,
+    onChange,
+    onStrengthChange,
+    disabled,
+  }: {
+    id?: string;
+    placeholder?: string;
+    value?: string;
+    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    onStrengthChange?: (result: {
+      score: number;
+      isAcceptable: boolean;
+      crackTimeDisplay: string;
+      crackTimeSeconds: number;
+      feedback: { warning: string; suggestions: string[] };
+    }) => void;
+    disabled?: boolean;
+  }) => (
+    <input
+      id={id}
+      type="password"
+      placeholder={placeholder}
+      value={value}
+      disabled={disabled}
+      onChange={(event) => {
+        onChange?.(event);
+        onStrengthChange?.({
+          score: 4,
+          isAcceptable: true,
+          crackTimeDisplay: "centuries",
+          crackTimeSeconds: 999_999,
+          feedback: { warning: "", suggestions: [] },
+        });
+      }}
+    />
+  ),
+}));
+
+async function fillSignUpForm() {
+  await userEvent.type(screen.getByLabelText("Name"), "Avery Quinn");
+  await userEvent.type(screen.getByLabelText("Email"), "avery@example.com");
+  await userEvent.type(screen.getByLabelText("Password"), "CorrectHorseBatteryStaple!2026");
+}
+
+describe("auth form flows", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.fetch = vi.fn(async () => Response.json({ valid: true })) as unknown as typeof fetch;
+    mocks.signUpEmail.mockResolvedValue({ data: {}, error: null });
+    mocks.signInEmail.mockResolvedValue({ data: {}, error: null });
+    mocks.requestPasswordReset.mockResolvedValue({ data: {}, error: null });
+  });
+
+  it("blocks sign up when disposable email validation returns a reason", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      Response.json({ valid: false, reason: "Please use a permanent email address" }),
+    ) as unknown as typeof fetch;
+
+    render(<SignUpForm />);
+    await userEvent.type(screen.getByLabelText("Email"), "temp@example.com");
+    screen.getByLabelText("Email").blur();
+
+    await waitFor(() =>
+      expect(screen.getByText("Please use a permanent email address")).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /create account/i })).toBeDisabled();
+  });
+
+  it("creates an account and redirects to the requested callback URL", async () => {
+    const onSuccess = vi.fn();
+    render(<SignUpForm callbackURL="/wizard?from=test" onSuccess={onSuccess} />);
+    await fillSignUpForm();
+
+    await userEvent.click(screen.getByRole("button", { name: /create account/i }));
+
+    await waitFor(() =>
+      expect(mocks.signUpEmail).toHaveBeenCalledWith({
+        name: "Avery Quinn",
+        email: "avery@example.com",
+        password: "CorrectHorseBatteryStaple!2026",
+        callbackURL: "/wizard?from=test",
+      }),
+    );
+    expect(mocks.toast.success).toHaveBeenCalledWith(
+      "Account created! Check your email to verify your address.",
+    );
+    expect(onSuccess).toHaveBeenCalled();
+    expect(mocks.router.push).toHaveBeenCalledWith("/wizard?from=test");
+  });
+
+  it("maps sign up provider errors to user-facing toast messages", async () => {
+    const cases = [
+      ["email already exists", "An account with this email already exists"],
+      ["password too weak", "Password does not meet requirements"],
+      ["use a permanent email", "Please use a permanent email address to sign up"],
+      ["server unavailable", "server unavailable"],
+    ] as const;
+
+    for (const [providerMessage, toastMessage] of cases) {
+      mocks.signUpEmail.mockResolvedValueOnce({ data: null, error: { message: providerMessage } });
+      const { unmount } = render(<SignUpForm />);
+      await fillSignUpForm();
+      await userEvent.click(screen.getByRole("button", { name: /create account/i }));
+      await waitFor(() => expect(mocks.toast.error).toHaveBeenCalledWith(toastMessage));
+      unmount();
+      mocks.toast.error.mockClear();
+    }
+  });
+
+  it("signs in, handles credential errors, and exposes forgot-password navigation", async () => {
+    const onSuccess = vi.fn();
+    const onForgotPassword = vi.fn();
+    const { unmount } = render(
+      <SignInForm
+        callbackURL="/dashboard?welcome=1"
+        onSuccess={onSuccess}
+        onForgotPassword={onForgotPassword}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /forgot password/i }));
+    expect(onForgotPassword).toHaveBeenCalled();
+
+    await userEvent.type(screen.getByLabelText("Email"), "avery@example.com");
+    await userEvent.type(screen.getByLabelText("Password"), "password123");
+    await userEvent.click(screen.getByRole("button", { name: /^sign in$/i }));
+
+    await waitFor(() =>
+      expect(mocks.signInEmail).toHaveBeenCalledWith({
+        email: "avery@example.com",
+        password: "password123",
+        callbackURL: "/dashboard?welcome=1",
+      }),
+    );
+    expect(onSuccess).toHaveBeenCalled();
+    expect(mocks.router.push).toHaveBeenCalledWith("/dashboard?welcome=1");
+    unmount();
+
+    mocks.signInEmail.mockResolvedValueOnce({
+      data: null,
+      error: { message: "invalid credentials" },
+    });
+    render(<SignInForm />);
+    await userEvent.type(screen.getByLabelText("Email"), "avery@example.com");
+    await userEvent.type(screen.getByLabelText("Password"), "wrongpass");
+    await userEvent.click(screen.getByRole("button", { name: /^sign in$/i }));
+    await waitFor(() =>
+      expect(mocks.toast.error).toHaveBeenCalledWith("Invalid email or password"),
+    );
+  });
+
+  it("requests password reset and shows the non-enumerating success state", async () => {
+    const onBack = vi.fn();
+    render(<ForgotPasswordForm onBackToSignIn={onBack} />);
+    await userEvent.type(screen.getByLabelText("Email"), "avery@example.com");
+    await userEvent.click(screen.getByRole("button", { name: /send reset link/i }));
+
+    await waitFor(() =>
+      expect(mocks.requestPasswordReset).toHaveBeenCalledWith({
+        email: "avery@example.com",
+        redirectTo: "/reset-password",
+      }),
+    );
+    expect(screen.getByText("Check your email")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /back to sign in/i }));
+    expect(onBack).toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/components/auth-forms.test.tsx
+++ b/__tests__/unit/components/auth-forms.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type React from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ForgotPasswordForm } from "@/components/auth/ForgotPasswordForm";
 import { SignInForm } from "@/components/auth/SignInForm";
 import { SignUpForm } from "@/components/auth/SignUpForm";
@@ -13,6 +13,8 @@ const mocks = vi.hoisted(() => ({
   signInEmail: vi.fn(),
   requestPasswordReset: vi.fn(),
 }));
+
+const originalFetch = globalThis.fetch;
 
 vi.mock("next/navigation", () => ({
   useRouter: () => mocks.router,
@@ -87,6 +89,10 @@ describe("auth form flows", () => {
     mocks.signUpEmail.mockResolvedValue({ data: {}, error: null });
     mocks.signInEmail.mockResolvedValue({ data: {}, error: null });
     mocks.requestPasswordReset.mockResolvedValue({ data: {}, error: null });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
   });
 
   it("blocks sign up when disposable email validation returns a reason", async () => {

--- a/__tests__/unit/components/auth-forms.test.tsx
+++ b/__tests__/unit/components/auth-forms.test.tsx
@@ -93,7 +93,7 @@ describe("auth form flows", () => {
 
   afterEach(() => {
     if (originalFetch === undefined) {
-      delete (globalThis as any).fetch;
+      delete (globalThis as { fetch?: typeof fetch }).fetch;
     } else {
       globalThis.fetch = originalFetch;
     }

--- a/__tests__/unit/components/branch-heavy-components.test.tsx
+++ b/__tests__/unit/components/branch-heavy-components.test.tsx
@@ -148,6 +148,22 @@ const resumeContent: ResumeContent = {
   certifications: [],
 };
 
+const originalFetch = global.fetch;
+const originalWindowOpen = window.open;
+const originalNavigatorDescriptors = {
+  canShare: Object.getOwnPropertyDescriptor(navigator, "canShare"),
+  share: Object.getOwnPropertyDescriptor(navigator, "share"),
+};
+
+function restoreNavigatorProperty(property: "canShare" | "share") {
+  const descriptor = originalNavigatorDescriptors[property];
+  if (descriptor) {
+    Object.defineProperty(navigator, property, descriptor);
+    return;
+  }
+  Reflect.deleteProperty(navigator, property);
+}
+
 describe("branch-heavy component interactions", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -182,13 +198,17 @@ describe("branch-heavy component interactions", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+    global.fetch = originalFetch;
+    window.open = originalWindowOpen;
+    restoreNavigatorProperty("canShare");
+    restoreNavigatorProperty("share");
   });
 
   describe("HandleForm", () => {
     it("copies the public URL and resets the copied state", async () => {
       render(<HandleForm currentHandle="avery" />);
 
-      fireEvent.click(screen.getAllByRole("button")[0]);
+      fireEvent.click(screen.getByRole("button", { name: "Copy public URL" }));
 
       await waitFor(() =>
         expect(mocks.copyToClipboard).toHaveBeenCalledWith("https://clickfolio.me/@avery"),
@@ -201,7 +221,7 @@ describe("branch-heavy component interactions", () => {
 
       render(<HandleForm currentHandle="avery" variant="compact" />);
 
-      fireEvent.click(screen.getAllByRole("button")[0]);
+      fireEvent.click(screen.getByRole("button", { name: "Copy public URL" }));
       await waitFor(() => expect(mocks.toast.error).toHaveBeenCalledWith("Failed to copy URL"));
 
       fireEvent.submit(screen.getByLabelText("Change Handle").closest("form") as HTMLFormElement);
@@ -855,7 +875,7 @@ describe("branch-heavy component interactions", () => {
         "noopener,noreferrer",
       );
 
-      await user.click(screen.getAllByRole("button", { name: "" }).at(-1) as HTMLButtonElement);
+      await user.click(screen.getByRole("button", { name: "Copy referral link" }));
       expect(mocks.copyToClipboard).toHaveBeenCalledWith("http://localhost:3000/?ref=avery");
 
       await user.click(screen.getByRole("link", { name: /view my resume/i }));
@@ -881,7 +901,7 @@ describe("branch-heavy component interactions", () => {
       expect(mocks.copyToClipboard).toHaveBeenCalledWith("https://example.com/resume");
       expect(mocks.toast.error).toHaveBeenCalledWith("Failed to copy link");
 
-      await user.click(screen.getAllByRole("button", { name: "" }).at(-1) as HTMLButtonElement);
+      await user.click(screen.getByRole("button", { name: "Copy referral link" }));
       expect(mocks.toast.error).toHaveBeenCalledWith("Failed to copy link");
     });
   });

--- a/__tests__/unit/components/branch-heavy-components.test.tsx
+++ b/__tests__/unit/components/branch-heavy-components.test.tsx
@@ -1,0 +1,888 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GoogleButton } from "@/components/auth/GoogleButton";
+import { PasswordInput } from "@/components/auth/PasswordInput";
+import { CopyLinkButton } from "@/components/dashboard/CopyLinkButton";
+import { EmailVerificationBanner } from "@/components/dashboard/EmailVerificationBanner";
+import { MilestoneToasts } from "@/components/dashboard/MilestoneToasts";
+import { ReferralStats } from "@/components/dashboard/ReferralStats";
+import { EditResumeFormWrapper } from "@/components/forms/EditResumeFormWrapper";
+import { HandleForm } from "@/components/forms/HandleForm";
+import { ShareBar } from "@/components/ShareBar";
+import { TemplatePreviewModal } from "@/components/templates/TemplatePreviewModal";
+import { CommaArrayInput } from "@/components/ui/comma-array-input";
+import { SaveIndicator } from "@/components/ui/save-indicator";
+import { YouAreLiveModal } from "@/components/YouAreLiveModal";
+import { DEMO_PROFILES } from "@/lib/templates/demo-data";
+import type { ThemeId } from "@/lib/templates/theme-ids";
+import type { ResumeContent } from "@/lib/types/database";
+
+const mocks = vi.hoisted(() => ({
+  router: {
+    refresh: vi.fn(),
+  },
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    info: vi.fn(),
+  },
+  copyToClipboard: vi.fn(),
+  sendVerificationEmail: vi.fn(),
+  checkBreached: vi.fn(),
+  checkPasswordStrength: vi.fn(),
+  signInSocial: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => mocks.router,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    onClick,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a
+      href={href}
+      onClick={(event) => {
+        event.preventDefault();
+        onClick?.(event);
+      }}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("sonner", () => ({
+  toast: mocks.toast,
+}));
+
+vi.mock("@/lib/utils/clipboard", () => ({
+  copyToClipboard: (...args: unknown[]) => mocks.copyToClipboard(...args),
+}));
+
+vi.mock("@/lib/auth/client", () => ({
+  sendVerificationEmail: (...args: unknown[]) => mocks.sendVerificationEmail(...args),
+  signIn: {
+    social: (...args: unknown[]) => mocks.signInSocial(...args),
+  },
+}));
+
+vi.mock("@/lib/password/hibp", () => ({
+  checkBreached: (...args: unknown[]) => mocks.checkBreached(...args),
+}));
+
+vi.mock("@/lib/password/strength", () => ({
+  checkPasswordStrength: (...args: unknown[]) => mocks.checkPasswordStrength(...args),
+}));
+
+vi.mock("@/lib/templates/theme-registry.client", () => ({
+  DYNAMIC_TEMPLATES: Object.fromEntries(
+    [
+      "bento",
+      "bold_corporate",
+      "classic_ats",
+      "design_folio",
+      "dev_terminal",
+      "glass",
+      "midnight",
+      "minimalist_editorial",
+      "neo_brutalist",
+      "spotlight",
+    ].map((themeId) => [
+      themeId,
+      ({ content, profile }: { content: { full_name?: string }; profile: { handle: string } }) => (
+        <article data-testid={`template-${themeId}`}>
+          {content.full_name} {profile.handle}
+        </article>
+      ),
+    ]),
+  ) as Record<ThemeId, React.ComponentType<unknown>>,
+}));
+
+vi.mock("@/components/forms/EditResumeForm", () => ({
+  EditResumeForm: ({
+    initialData,
+    onSave,
+  }: {
+    initialData: ResumeContent;
+    onSave: (data: ResumeContent, isAutoSave?: boolean) => Promise<void>;
+  }) => (
+    <div>
+      <button type="button" onClick={() => onSave(initialData, false).catch(() => undefined)}>
+        Publish Changes
+      </button>
+      <button type="button" onClick={() => onSave(initialData, true).catch(() => undefined)}>
+        Autosave
+      </button>
+    </div>
+  ),
+}));
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+const resumeContent: ResumeContent = {
+  full_name: "Avery Quinn",
+  headline: "Staff Product Engineer",
+  summary: "Builds resilient products.",
+  contact: {
+    email: "avery@example.com",
+    location: "Phoenix, AZ",
+  },
+  experience: [],
+  education: [],
+  skills: [],
+  projects: [],
+  certifications: [],
+};
+
+describe("branch-heavy component interactions", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    localStorage.clear();
+    mocks.copyToClipboard.mockResolvedValue(true);
+    mocks.sendVerificationEmail.mockResolvedValue({ data: {}, error: null });
+    mocks.checkBreached.mockResolvedValue({ isBreached: false, count: 0 });
+    mocks.checkPasswordStrength.mockResolvedValue({
+      score: 4,
+      isAcceptable: true,
+      crackTimeDisplay: "centuries",
+      crackTimeSeconds: 31_536_000_000,
+      feedback: { warning: "", suggestions: [] },
+    });
+    mocks.signInSocial.mockResolvedValue({ data: {}, error: null });
+    global.fetch = vi.fn(async () =>
+      Response.json({ handle: "new-handle" }, { status: 200 }),
+    ) as unknown as typeof fetch;
+    window.open = vi.fn();
+    Object.defineProperty(navigator, "canShare", {
+      value: vi.fn(() => true),
+      configurable: true,
+    });
+    Object.defineProperty(navigator, "share", {
+      value: vi.fn(async () => undefined),
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("HandleForm", () => {
+    it("copies the public URL and resets the copied state", async () => {
+      render(<HandleForm currentHandle="avery" />);
+
+      fireEvent.click(screen.getAllByRole("button")[0]);
+
+      await waitFor(() =>
+        expect(mocks.copyToClipboard).toHaveBeenCalledWith("https://clickfolio.me/@avery"),
+      );
+      expect(mocks.toast.success).toHaveBeenCalledWith("URL copied to clipboard");
+    });
+
+    it("reports copy failures and avoids saving an unchanged compact handle", async () => {
+      mocks.copyToClipboard.mockResolvedValueOnce(false);
+
+      render(<HandleForm currentHandle="avery" variant="compact" />);
+
+      fireEvent.click(screen.getAllByRole("button")[0]);
+      await waitFor(() => expect(mocks.toast.error).toHaveBeenCalledWith("Failed to copy URL"));
+
+      fireEvent.submit(screen.getByLabelText("Change Handle").closest("form") as HTMLFormElement);
+      await waitFor(() =>
+        expect(mocks.toast.info).toHaveBeenCalledWith("Handle is already set to this value"),
+      );
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("updates a changed handle, refreshes the route, and reports API failures", async () => {
+      const user = userEvent.setup();
+      const { rerender } = render(<HandleForm currentHandle="avery" />);
+
+      await user.clear(screen.getByLabelText("Change Handle"));
+      await user.type(screen.getByLabelText("Change Handle"), "new-handle");
+      expect(screen.getByText("https://clickfolio.me/@new-handle")).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Update Handle" }));
+
+      await waitFor(() =>
+        expect(fetch).toHaveBeenCalledWith(
+          "/api/profile/handle",
+          expect.objectContaining({
+            method: "PUT",
+            body: JSON.stringify({ handle: "new-handle" }),
+          }),
+        ),
+      );
+      expect(mocks.toast.success).toHaveBeenCalledWith("Handle updated successfully!");
+      expect(mocks.router.refresh).toHaveBeenCalled();
+
+      vi.mocked(fetch).mockResolvedValueOnce(
+        Response.json({ message: "Handle is taken" }, { status: 409 }),
+      );
+      rerender(<HandleForm currentHandle="avery" />);
+
+      await user.clear(screen.getByLabelText("Change Handle"));
+      await user.type(screen.getByLabelText("Change Handle"), "taken-handle");
+      await user.click(screen.getByRole("button", { name: "Update Handle" }));
+
+      await waitFor(() => expect(mocks.toast.error).toHaveBeenCalledWith("Handle is taken"));
+    });
+
+    it("shows validation errors and reports thrown update failures", async () => {
+      const user = userEvent.setup();
+      render(<HandleForm currentHandle="avery" variant="compact" />);
+
+      await user.clear(screen.getByLabelText("Change Handle"));
+      await user.type(screen.getByLabelText("Change Handle"), "Nope!");
+      await user.click(screen.getByRole("button", { name: "Update" }));
+
+      expect(
+        await screen.findByText("Handle can only contain lowercase letters, numbers, and hyphens"),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Update" })).toBeDisabled();
+
+      vi.mocked(fetch).mockRejectedValueOnce("network");
+      await user.clear(screen.getByLabelText("Change Handle"));
+      await user.type(screen.getByLabelText("Change Handle"), "new-handle");
+      await user.click(screen.getByRole("button", { name: "Update" }));
+
+      await waitFor(() =>
+        expect(mocks.toast.error).toHaveBeenCalledWith("Failed to update handle"),
+      );
+    });
+  });
+
+  describe("EmailVerificationBanner", () => {
+    it("stays hidden for verified, OAuth, and recently dismissed users", () => {
+      const now = Date.now();
+      vi.spyOn(Date, "now").mockReturnValue(now);
+      localStorage.setItem("email_verification_dismissed", now.toString());
+
+      const { rerender } = render(
+        <EmailVerificationBanner email="avery@example.com" emailVerified isOAuthUser={false} />,
+      );
+      expect(screen.queryByText("Verify your email")).not.toBeInTheDocument();
+
+      rerender(
+        <EmailVerificationBanner email="avery@example.com" emailVerified={false} isOAuthUser />,
+      );
+      expect(screen.queryByText("Verify your email")).not.toBeInTheDocument();
+
+      rerender(
+        <EmailVerificationBanner
+          email="avery@example.com"
+          emailVerified={false}
+          isOAuthUser={false}
+        />,
+      );
+      expect(screen.queryByText("Verify your email")).not.toBeInTheDocument();
+    });
+
+    it("resends verification email, runs cooldown, and dismisses the banner", async () => {
+      vi.useFakeTimers();
+
+      render(
+        <EmailVerificationBanner
+          email="avery@example.com"
+          emailVerified={false}
+          isOAuthUser={false}
+        />,
+      );
+
+      expect(screen.getByText("Verify your email")).toBeInTheDocument();
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Resend verification email" }));
+        await flushMicrotasks();
+      });
+
+      expect(mocks.sendVerificationEmail).toHaveBeenCalledWith({
+        email: "avery@example.com",
+        callbackURL: "/verify-email",
+      });
+      expect(mocks.toast.success).toHaveBeenCalledWith(
+        "Verification email sent! Check your inbox.",
+      );
+      expect(screen.getByRole("button", { name: "Resend in 60s" })).toBeDisabled();
+
+      fireEvent.click(screen.getByRole("button", { name: "Resend in 60s" }));
+      expect(mocks.sendVerificationEmail).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        vi.advanceTimersByTime(60_000);
+      });
+      expect(screen.getByRole("button", { name: "Resend verification email" })).toBeEnabled();
+
+      fireEvent.click(screen.getByLabelText("Dismiss"));
+      expect(screen.queryByText("Verify your email")).not.toBeInTheDocument();
+      expect(localStorage.getItem("email_verification_dismissed")).toBeTruthy();
+    });
+
+    it("clears expired dismissal and reports resend errors", async () => {
+      vi.spyOn(Date, "now").mockReturnValue(9 * 24 * 60 * 60 * 1000);
+      localStorage.setItem("email_verification_dismissed", "0");
+      mocks.sendVerificationEmail
+        .mockResolvedValueOnce({ error: { message: "Mail quota reached" } })
+        .mockRejectedValueOnce(new Error("network"));
+      const user = userEvent.setup();
+
+      render(
+        <EmailVerificationBanner
+          email="avery@example.com"
+          emailVerified={false}
+          isOAuthUser={false}
+        />,
+      );
+
+      expect(await screen.findByText("Verify your email")).toBeInTheDocument();
+      expect(localStorage.getItem("email_verification_dismissed")).toBeNull();
+
+      await user.click(screen.getByRole("button", { name: "Resend verification email" }));
+      expect(mocks.toast.error).toHaveBeenCalledWith("Mail quota reached");
+
+      await user.click(screen.getByRole("button", { name: "Resend verification email" }));
+      await waitFor(() =>
+        expect(mocks.toast.error).toHaveBeenCalledWith("Something went wrong. Please try again."),
+      );
+    });
+  });
+
+  describe("PasswordInput", () => {
+    it("supports uncontrolled visibility toggling without the strength meter", async () => {
+      const user = userEvent.setup();
+      render(<PasswordInput aria-label="Password" hasError className="custom-class" />);
+
+      const input = screen.getByLabelText("Password");
+      expect(input).toHaveAttribute("type", "password");
+
+      await user.type(input, "secret");
+      expect(input).toHaveValue("secret");
+      expect(screen.queryByText("Strong")).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Show password" }));
+      expect(input).toHaveAttribute("type", "text");
+      await user.click(screen.getByRole("button", { name: "Hide password" }));
+      expect(input).toHaveAttribute("type", "password");
+    });
+
+    it("debounces strength and breach checks for controlled values", async () => {
+      vi.useFakeTimers();
+      const onStrengthChange = vi.fn();
+
+      render(
+        <PasswordInput
+          aria-label="Password"
+          checkBreach
+          email="avery@example.com"
+          name="Avery"
+          onStrengthChange={onStrengthChange}
+          showStrengthMeter
+          value="long-password"
+        />,
+      );
+
+      await act(async () => {
+        vi.advanceTimersByTime(150);
+        await flushMicrotasks();
+      });
+      expect(mocks.checkPasswordStrength).toHaveBeenCalledWith("long-password", [
+        "avery@example.com",
+        "Avery",
+      ]);
+      expect(onStrengthChange).toHaveBeenCalledWith(expect.any(Object));
+
+      await act(async () => {
+        vi.advanceTimersByTime(350);
+        await flushMicrotasks();
+      });
+      expect(mocks.checkBreached).toHaveBeenCalledWith("long-password");
+    });
+
+    it("clears strength state and skips breach checks for short or empty values", async () => {
+      const onStrengthChange = vi.fn();
+      const { rerender } = render(
+        <PasswordInput
+          aria-label="Password"
+          checkBreach
+          onStrengthChange={onStrengthChange}
+          showStrengthMeter
+          value="short"
+        />,
+      );
+
+      expect(screen.getByLabelText("Password")).toHaveValue("short");
+      expect(mocks.checkBreached).not.toHaveBeenCalled();
+
+      rerender(
+        <PasswordInput
+          aria-label="Password"
+          checkBreach
+          onStrengthChange={onStrengthChange}
+          showStrengthMeter
+          value=""
+        />,
+      );
+
+      expect(onStrengthChange).toHaveBeenCalledWith(null);
+      expect(screen.queryByText("Very Weak")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("GoogleButton", () => {
+    it("starts Google sign-in, shows loading state, and calls success callbacks", async () => {
+      const user = userEvent.setup();
+      const onSuccess = vi.fn();
+      let resolveSignIn: (value: unknown) => void = () => undefined;
+      mocks.signInSocial.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSignIn = resolve;
+          }),
+      );
+
+      render(
+        <GoogleButton
+          callbackURL="/dashboard"
+          fullWidth
+          onSuccess={onSuccess}
+          text="Sign in with Google"
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Sign in with Google" }));
+      expect(screen.getByRole("button", { name: /signing in/i })).toBeDisabled();
+      expect(mocks.signInSocial).toHaveBeenCalledWith({
+        provider: "google",
+        callbackURL: "/dashboard",
+      });
+
+      await act(async () => {
+        resolveSignIn({ data: {}, error: null });
+        await flushMicrotasks();
+      });
+      expect(onSuccess).toHaveBeenCalled();
+    });
+
+    it.each([
+      [new Error("Popup blocked"), "Popup blocked. Please allow popups for this site."],
+      [new Error("network fetch failed"), "Network error. Check your connection."],
+      [new Error("user cancelled"), "Sign in was cancelled."],
+      [new Error("oauth failed"), "Sign in failed. Please try again."],
+      ["blocked", "Sign in failed. Please try again."],
+    ])("maps sign-in error %s to a friendly toast", async (error, message) => {
+      const user = userEvent.setup();
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      mocks.signInSocial.mockRejectedValueOnce(error);
+
+      render(<GoogleButton />);
+
+      await user.click(screen.getByRole("button", { name: "Continue with Google" }));
+
+      await waitFor(() => expect(mocks.toast.error).toHaveBeenCalledWith(message));
+      expect(consoleError).toHaveBeenCalledWith("Google sign in error:", error);
+    });
+
+    it("does not submit when externally disabled", async () => {
+      const user = userEvent.setup();
+
+      render(<GoogleButton disabled />);
+
+      await user.click(screen.getByRole("button", { name: "Continue with Google" }));
+      expect(mocks.signInSocial).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("TemplatePreviewModal", () => {
+    it("returns null for invalid selected indexes and inactive keyboard listeners", () => {
+      const onNavigate = vi.fn();
+      const { container, rerender } = render(
+        <TemplatePreviewModal
+          isOpen
+          onClose={vi.fn()}
+          onNavigate={onNavigate}
+          selectedIndex={999}
+        />,
+      );
+      expect(container).toBeEmptyDOMElement();
+
+      rerender(
+        <TemplatePreviewModal
+          isOpen={false}
+          onClose={vi.fn()}
+          onNavigate={onNavigate}
+          selectedIndex={0}
+        />,
+      );
+      fireEvent.keyDown(window, { key: "ArrowRight" });
+      expect(onNavigate).not.toHaveBeenCalled();
+    });
+
+    it("navigates with buttons, wraps at the ends, and handles arrow keys", async () => {
+      const user = userEvent.setup();
+      const onNavigate = vi.fn();
+      const onClose = vi.fn();
+      const { rerender } = render(
+        <TemplatePreviewModal isOpen onClose={onClose} onNavigate={onNavigate} selectedIndex={0} />,
+      );
+
+      expect(screen.getByText("Minimalist Editorial")).toBeInTheDocument();
+      expect(screen.getByTestId("template-minimalist_editorial")).toHaveTextContent("Sarah Chen");
+
+      await user.click(screen.getByRole("button", { name: "Previous template" }));
+      expect(onNavigate).toHaveBeenLastCalledWith(DEMO_PROFILES.length - 1);
+
+      await user.click(screen.getByRole("button", { name: "Next template" }));
+      expect(onNavigate).toHaveBeenLastCalledWith(1);
+
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+      expect(onNavigate).toHaveBeenLastCalledWith(DEMO_PROFILES.length - 1);
+
+      rerender(
+        <TemplatePreviewModal
+          isOpen
+          onClose={onClose}
+          onNavigate={onNavigate}
+          selectedIndex={DEMO_PROFILES.length - 1}
+        />,
+      );
+      fireEvent.keyDown(window, { key: "ArrowRight" });
+      expect(onNavigate).toHaveBeenLastCalledWith(0);
+
+      await user.click(screen.getByRole("button", { name: "Close preview" }));
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it("uses dark modal chrome for dark template backgrounds", () => {
+      render(
+        <TemplatePreviewModal isOpen onClose={vi.fn()} onNavigate={vi.fn()} selectedIndex={5} />,
+      );
+
+      expect(screen.getByText("Midnight")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Next template" })).toHaveClass("text-slate-300");
+    });
+  });
+
+  describe("ShareBar", () => {
+    it("uses native sharing, social targets, and handle-derived copy URLs", async () => {
+      const user = userEvent.setup();
+      render(<ShareBar handle="avery" name="" title="Avery Portfolio" variant="dev-terminal" />);
+
+      expect(await screen.findByRole("button", { name: "Share this page" })).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Share this page" }));
+      expect(navigator.share).toHaveBeenCalledWith({
+        title: "Avery Portfolio",
+        text: "Check out someone's portfolio",
+        url: "http://localhost:3000/@avery",
+      });
+
+      await user.click(screen.getByRole("button", { name: "Share on X (Twitter)" }));
+      expect(window.open).toHaveBeenLastCalledWith(
+        expect.stringContaining("https://twitter.com/intent/tweet?"),
+        "_blank",
+        "noopener,noreferrer",
+      );
+
+      await user.click(screen.getByRole("button", { name: "Share on LinkedIn" }));
+      expect(window.open).toHaveBeenLastCalledWith(
+        expect.stringContaining("https://www.linkedin.com/sharing/share-offsite/"),
+        "_blank",
+        "noopener,noreferrer",
+      );
+
+      await user.click(screen.getByRole("button", { name: "Share on WhatsApp" }));
+      expect(window.open).toHaveBeenLastCalledWith(
+        expect.stringContaining("https://wa.me/?"),
+        "_blank",
+        "noopener,noreferrer",
+      );
+
+      await user.click(screen.getByRole("button", { name: "Copy link" }));
+      expect(mocks.copyToClipboard).toHaveBeenCalledWith("http://localhost:3000/@avery");
+      expect(mocks.toast.success).toHaveBeenCalledWith("Link copied!");
+    });
+
+    it("hides native sharing when unsupported and reports copy/native share failures", async () => {
+      const user = userEvent.setup();
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      Object.defineProperty(navigator, "canShare", {
+        value: undefined,
+        configurable: true,
+      });
+      mocks.copyToClipboard.mockRejectedValueOnce(new Error("blocked"));
+
+      const { unmount } = render(
+        <ShareBar
+          name="Avery Quinn"
+          title="Avery"
+          url="https://clickfolio.me/@avery"
+          variant="minimalist-editorial"
+        />,
+      );
+
+      expect(screen.queryByRole("button", { name: "Share this page" })).not.toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: "Copy link" }));
+      expect(mocks.toast.error).toHaveBeenCalledWith("Failed to copy link");
+
+      unmount();
+      Object.defineProperty(navigator, "canShare", {
+        value: vi.fn(() => true),
+        configurable: true,
+      });
+      Object.defineProperty(navigator, "share", {
+        value: vi.fn(async () => {
+          throw new Error("share blocked");
+        }),
+        configurable: true,
+      });
+      render(
+        <ShareBar
+          name="Avery Quinn"
+          title="Avery"
+          url="https://clickfolio.me/@avery"
+          variant="glass-morphic"
+        />,
+      );
+
+      expect(await screen.findByRole("button", { name: "Share this page" })).toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: "Share this page" }));
+      expect(consoleError).toHaveBeenCalledWith("Share failed:", expect.any(Error));
+    });
+  });
+
+  describe("small dashboard and form helpers", () => {
+    it("shows one unshown milestone toast and cleans up pending milestone timers", () => {
+      vi.useFakeTimers();
+      localStorage.setItem("milestone_shown_1", "true");
+
+      const { unmount } = render(<MilestoneToasts totalViews={10} />);
+
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(mocks.toast.success).toHaveBeenCalledWith("📈 10 people have seen your portfolio!", {
+        duration: 5000,
+      });
+      expect(localStorage.getItem("milestone_shown_10")).toBe("true");
+
+      mocks.toast.success.mockClear();
+      unmount();
+      const pending = render(<MilestoneToasts totalViews={100} />);
+      pending.unmount();
+
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(mocks.toast.success).not.toHaveBeenCalled();
+    });
+
+    it("renders save indicator statuses and relative timestamps", () => {
+      vi.spyOn(Date, "now").mockReturnValue(new Date("2026-05-20T12:00:00Z").getTime());
+
+      const { container, rerender } = render(<SaveIndicator status="idle" />);
+      expect(container).toBeEmptyDOMElement();
+
+      rerender(<SaveIndicator status="saving" />);
+      expect(screen.getByText("Saving...")).toBeInTheDocument();
+
+      rerender(<SaveIndicator lastSaved={new Date("2026-05-20T11:59:30Z")} status="saved" />);
+      expect(screen.getByText("Saved just now")).toBeInTheDocument();
+
+      rerender(<SaveIndicator lastSaved={new Date("2026-05-20T11:50:00Z")} status="saved" />);
+      expect(screen.getByText("Saved 10m ago")).toBeInTheDocument();
+
+      rerender(<SaveIndicator lastSaved={new Date("2026-05-20T10:00:00Z")} status="saved" />);
+      expect(screen.getByText(/Saved/)).toBeInTheDocument();
+
+      rerender(<SaveIndicator status="saved" />);
+      expect(screen.queryByText(/Saved/)).not.toBeInTheDocument();
+
+      rerender(<SaveIndicator status="error" />);
+      expect(screen.getByText("Save failed")).toBeInTheDocument();
+
+      rerender(<SaveIndicator status="unsaved" />);
+      expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
+    });
+
+    it("normalizes comma-separated arrays and syncs external values when not focused", async () => {
+      const onChange = vi.fn();
+      const onBlur = vi.fn();
+      const { rerender } = render(
+        <CommaArrayInput
+          onBlur={onBlur}
+          onChange={onChange}
+          placeholder="Skills"
+          value={["React", "Cloudflare"]}
+        />,
+      );
+
+      const input = screen.getByPlaceholderText("Skills");
+      expect(input).toHaveValue("React, Cloudflare");
+
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: "React, , TypeScript " } });
+      rerender(
+        <CommaArrayInput
+          onBlur={onBlur}
+          onChange={onChange}
+          placeholder="Skills"
+          value={["Ignored"]}
+        />,
+      );
+      expect(input).toHaveValue("React, , TypeScript ");
+
+      fireEvent.blur(input);
+      expect(onChange).toHaveBeenCalledWith(["React", "TypeScript"]);
+      expect(onBlur).toHaveBeenCalled();
+      expect(input).toHaveValue("Ignored");
+
+      rerender(
+        <CommaArrayInput onChange={onChange} placeholder="Skills" value={["Workers", "D1"]} />,
+      );
+      expect(screen.getByPlaceholderText("Skills")).toHaveValue("Workers, D1");
+    });
+
+    it("copies dashboard and referral links and reports failures", async () => {
+      const user = userEvent.setup();
+      const { rerender } = render(
+        <div>
+          <CopyLinkButton handle="avery" />
+          <ReferralStats clickCount={0} referralCode="REF123" referralCount={0} />
+        </div>,
+      );
+
+      expect(screen.queryByText("0 clicks")).not.toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: "Copy Share Link" }));
+      expect(mocks.copyToClipboard).toHaveBeenCalledWith("http://localhost:3000/@avery");
+      expect(mocks.toast.success).toHaveBeenCalledWith("Link copied to clipboard!");
+
+      await user.click(screen.getByRole("button", { name: "Copy Link" }));
+      expect(mocks.copyToClipboard).toHaveBeenCalledWith("http://localhost:3000/?ref=REF123");
+      expect(mocks.toast.success).toHaveBeenCalledWith("Referral link copied!");
+
+      mocks.copyToClipboard.mockRejectedValueOnce(new Error("blocked"));
+      rerender(<ReferralStats clickCount={1} referralCode="REF456" referralCount={1} />);
+      expect(
+        screen.getAllByText((_, node) => node?.textContent === "1 click").length,
+      ).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText((_, node) => node?.textContent === "1 signup").length,
+      ).toBeGreaterThan(0);
+      expect(screen.getByText("100% conversion")).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Copy Link" }));
+      expect(mocks.toast.error).toHaveBeenCalledWith("Failed to copy link");
+    });
+
+    it("handles edit wrapper save success, autosave, and API error branches", async () => {
+      const user = userEvent.setup();
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(Response.json({ ok: true }))
+        .mockResolvedValueOnce(Response.json({ ok: true }))
+        .mockResolvedValueOnce(Response.json({ error: "too many edits" }, { status: 429 }))
+        .mockResolvedValueOnce(Response.json({ error: "expired" }, { status: 401 }))
+        .mockResolvedValueOnce(Response.json({ error: "bad content" }, { status: 400 }));
+
+      render(<EditResumeFormWrapper initialData={resumeContent} />);
+
+      await user.click(screen.getByRole("button", { name: "Publish Changes" }));
+      await waitFor(() => expect(mocks.router.refresh).toHaveBeenCalledTimes(1));
+
+      await user.click(screen.getByRole("button", { name: "Autosave" }));
+      await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+      expect(mocks.router.refresh).toHaveBeenCalledTimes(1);
+
+      await user.click(screen.getByRole("button", { name: "Publish Changes" }));
+      await waitFor(() =>
+        expect(mocks.toast.error).toHaveBeenCalledWith(
+          "Rate limit exceeded. Please try again later.",
+        ),
+      );
+
+      await user.click(screen.getByRole("button", { name: "Publish Changes" }));
+      await waitFor(() =>
+        expect(mocks.toast.error).toHaveBeenCalledWith("Session expired. Please log in again."),
+      );
+
+      await user.click(screen.getByRole("button", { name: "Publish Changes" }));
+      await waitFor(() => expect(mocks.toast.error).toHaveBeenCalledWith("bad content"));
+    });
+  });
+
+  describe("YouAreLiveModal", () => {
+    it("shares, copies resume and referral links, and closes through the view link", async () => {
+      const user = userEvent.setup();
+      const onOpenChange = vi.fn();
+      render(<YouAreLiveModal handle="avery" onOpenChange={onOpenChange} open />);
+
+      await user.click(screen.getByRole("button", { name: "Copy link" }));
+      expect(mocks.copyToClipboard).toHaveBeenCalledWith("http://localhost:3000/@avery");
+
+      await user.click(screen.getByRole("button", { name: "Share on LinkedIn" }));
+      expect(window.open).toHaveBeenLastCalledWith(
+        expect.stringContaining("https://www.linkedin.com/sharing/share-offsite/"),
+        "_blank",
+        "noopener,noreferrer",
+      );
+
+      await user.click(screen.getByRole("button", { name: "Twitter" }));
+      expect(window.open).toHaveBeenLastCalledWith(
+        expect.stringContaining("https://twitter.com/intent/tweet?"),
+        "_blank",
+        "noopener,noreferrer",
+      );
+
+      await user.click(screen.getByRole("button", { name: "WhatsApp" }));
+      expect(window.open).toHaveBeenLastCalledWith(
+        expect.stringContaining("https://wa.me/?"),
+        "_blank",
+        "noopener,noreferrer",
+      );
+
+      await user.click(screen.getAllByRole("button", { name: "" }).at(-1) as HTMLButtonElement);
+      expect(mocks.copyToClipboard).toHaveBeenCalledWith("http://localhost:3000/?ref=avery");
+
+      await user.click(screen.getByRole("link", { name: /view my resume/i }));
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it("uses explicit URLs and reports copy failures", async () => {
+      const user = userEvent.setup();
+      mocks.copyToClipboard
+        .mockRejectedValueOnce(new Error("blocked"))
+        .mockRejectedValueOnce(new Error("blocked"));
+
+      render(
+        <YouAreLiveModal
+          handle="avery"
+          onOpenChange={vi.fn()}
+          open
+          url="https://example.com/resume"
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Copy link" }));
+      expect(mocks.copyToClipboard).toHaveBeenCalledWith("https://example.com/resume");
+      expect(mocks.toast.error).toHaveBeenCalledWith("Failed to copy link");
+
+      await user.click(screen.getAllByRole("button", { name: "" }).at(-1) as HTMLButtonElement);
+      expect(mocks.toast.error).toHaveBeenCalledWith("Failed to copy link");
+    });
+  });
+});

--- a/__tests__/unit/components/realtime-status-listener.test.tsx
+++ b/__tests__/unit/components/realtime-status-listener.test.tsx
@@ -1,0 +1,130 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RealtimeStatusListener } from "@/components/dashboard/RealtimeStatusListener";
+
+const mocks = vi.hoisted(() => {
+  let socketArgs: null | {
+    resumeId: string | null;
+    onStatusChange: (status: string, errorMessage?: string) => void;
+  } = null;
+
+  return {
+    router: {
+      refresh: vi.fn(),
+    },
+    get socketArgs() {
+      return socketArgs;
+    },
+    set socketArgs(value) {
+      socketArgs = value;
+    },
+    useResumeWebSocket: vi.fn(
+      (args: {
+        resumeId: string | null;
+        onStatusChange: (status: string, error?: string) => void;
+      }) => {
+        socketArgs = args;
+      },
+    ),
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => mocks.router,
+}));
+
+vi.mock("@/hooks/useResumeWebSocket", () => ({
+  useResumeWebSocket: (...args: Parameters<typeof mocks.useResumeWebSocket>) =>
+    mocks.useResumeWebSocket(...args),
+}));
+
+describe("RealtimeStatusListener", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mocks.socketArgs = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each(["processing", "queued"])("connects while %s and renders processing state", (status) => {
+    render(
+      <RealtimeStatusListener currentStatus={status} resumeId="resume_123" userId="user_123" />,
+    );
+
+    expect(screen.getByText("Processing Your Resume")).toBeInTheDocument();
+    expect(mocks.socketArgs?.resumeId).toBe("resume_123");
+  });
+
+  it("does not connect for terminal initial statuses", () => {
+    const { unmount } = render(
+      <RealtimeStatusListener currentStatus="completed" resumeId="resume_123" userId="user_123" />,
+    );
+
+    expect(screen.getByText("Processing Complete!")).toBeInTheDocument();
+    const completedSocketArgs = mocks.socketArgs as { resumeId: string | null } | null;
+    expect(completedSocketArgs?.resumeId).toBeNull();
+
+    unmount();
+    mocks.socketArgs = null;
+    render(
+      <RealtimeStatusListener currentStatus="failed" resumeId="resume_456" userId="user_123" />,
+    );
+
+    expect(screen.getByText("Processing Failed")).toBeInTheDocument();
+    expect(screen.getByText("An error occurred while processing your resume.")).toBeInTheDocument();
+    const failedSocketArgs = mocks.socketArgs as { resumeId: string | null } | null;
+    expect(failedSocketArgs?.resumeId).toBeNull();
+  });
+
+  it("reacts to completed and failed socket updates with one debounced refresh", async () => {
+    render(
+      <RealtimeStatusListener currentStatus="processing" resumeId="resume_123" userId="user_123" />,
+    );
+
+    await act(async () => {
+      mocks.socketArgs?.onStatusChange("completed");
+    });
+
+    expect(screen.getByText("Processing Complete!")).toBeInTheDocument();
+    expect(mocks.router.refresh).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(mocks.router.refresh).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      mocks.socketArgs?.onStatusChange("failed", "Parser crashed");
+      vi.advanceTimersByTime(200);
+    });
+    expect(mocks.router.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces a pending refresh timer when a later terminal update arrives", async () => {
+    render(
+      <RealtimeStatusListener currentStatus="queued" resumeId="resume_123" userId="user_123" />,
+    );
+
+    await act(async () => {
+      mocks.socketArgs?.onStatusChange("completed");
+      vi.advanceTimersByTime(100);
+      mocks.socketArgs?.onStatusChange("failed", "AI provider failed");
+    });
+
+    expect(screen.getByText("Processing Failed")).toBeInTheDocument();
+    expect(screen.getByText("AI provider failed")).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(mocks.router.refresh).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(mocks.router.refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/unit/components/settings-forms.test.tsx
+++ b/__tests__/unit/components/settings-forms.test.tsx
@@ -159,8 +159,10 @@ describe("ThemeSelector", () => {
 
   afterEach(() => {
     vi.useRealTimers();
-    if (originalOffsetWidth) {
+    if (originalOffsetWidth !== undefined) {
       Object.defineProperty(HTMLElement.prototype, "offsetWidth", originalOffsetWidth);
+    } else {
+      delete (HTMLElement.prototype as { offsetWidth?: number }).offsetWidth;
     }
   });
 

--- a/__tests__/unit/components/settings-forms.test.tsx
+++ b/__tests__/unit/components/settings-forms.test.tsx
@@ -1,0 +1,219 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ThemeSelector } from "@/components/dashboard/ThemeSelector";
+import { PrivacySettingsForm } from "@/components/forms/PrivacySettings";
+import type { ResumeContent } from "@/lib/types/database";
+
+const mocks = vi.hoisted(() => ({
+  router: {
+    refresh: vi.fn(),
+  },
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => mocks.router,
+}));
+
+vi.mock("sonner", () => ({
+  toast: mocks.toast,
+  Toaster: () => null,
+}));
+
+vi.mock("@/lib/templates/theme-registry.client", () => {
+  const themeIds = [
+    "bento",
+    "bold_corporate",
+    "classic_ats",
+    "design_folio",
+    "dev_terminal",
+    "glass",
+    "midnight",
+    "minimalist_editorial",
+    "neo_brutalist",
+    "spotlight",
+  ];
+  return {
+    DYNAMIC_TEMPLATES: Object.fromEntries(
+      themeIds.map((id) => [
+        id,
+        ({ content }: { content: { full_name?: string } }) => (
+          <div data-testid="theme-preview">
+            {id}:{content.full_name}
+          </div>
+        ),
+      ]),
+    ),
+  };
+});
+
+const resumeContent: ResumeContent = {
+  full_name: "Avery Quinn",
+  headline: "Product Engineer",
+  summary: "Builds reliable products.",
+  contact: { email: "avery@example.com" },
+  experience: [],
+  education: [],
+  skills: [],
+  certifications: [],
+  projects: [],
+};
+
+describe("PrivacySettingsForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.fetch = vi.fn(async () =>
+      Response.json({ success: true }),
+    ) as unknown as typeof fetch;
+  });
+
+  it("saves each privacy toggle and updates visible status labels", async () => {
+    const user = userEvent.setup();
+    render(
+      <PrivacySettingsForm
+        userHandle="avery"
+        initialSettings={{
+          show_phone: false,
+          show_address: false,
+          hide_from_search: false,
+          show_in_directory: false,
+        }}
+      />,
+    );
+
+    const switches = screen.getAllByRole("switch");
+    await user.click(switches[0]);
+    await waitFor(() =>
+      expect(mocks.toast.success).toHaveBeenCalledWith("Privacy settings updated"),
+    );
+    expect(globalThis.fetch).toHaveBeenLastCalledWith(
+      "/api/profile/privacy",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({
+          show_phone: true,
+          show_address: false,
+          hide_from_search: false,
+          show_in_directory: false,
+        }),
+      }),
+    );
+    expect(screen.getAllByText("Visible").length).toBeGreaterThan(0);
+
+    await user.click(switches[1]);
+    await user.click(switches[2]);
+    await user.click(switches[3]);
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(4));
+    expect(screen.getAllByText("Full address").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Hidden").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Listed").length).toBeGreaterThan(0);
+  });
+
+  it("surfaces API and thrown privacy update failures", async () => {
+    const user = userEvent.setup();
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(Response.json({ message: "Privacy rejected" }, { status: 400 }))
+      .mockRejectedValueOnce("network");
+
+    render(
+      <PrivacySettingsForm
+        userHandle={null}
+        initialSettings={{
+          show_phone: true,
+          show_address: true,
+          hide_from_search: true,
+          show_in_directory: true,
+        }}
+      />,
+    );
+
+    const switches = screen.getAllByRole("switch");
+    await user.click(switches[0]);
+    await waitFor(() => expect(mocks.toast.error).toHaveBeenCalledWith("Privacy rejected"));
+
+    await user.click(switches[1]);
+    await waitFor(() =>
+      expect(mocks.toast.error).toHaveBeenCalledWith("Failed to update privacy settings"),
+    );
+  });
+});
+
+describe("ThemeSelector", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.fetch = vi.fn(async () =>
+      Response.json({ success: true }),
+    ) as unknown as typeof fetch;
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+      configurable: true,
+      get: () => 640,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("prevents locked click selection and applies an unlocked theme", async () => {
+    render(
+      <ThemeSelector
+        initialThemeId="bento"
+        initialContent={resumeContent}
+        profile={{ handle: "avery", avatar_url: null }}
+        referralCount={0}
+        isPro={false}
+      />,
+    );
+
+    expect(screen.getAllByText("Bento Grid").length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByRole("option", { name: /DesignFolio/ }));
+    expect(screen.queryByRole("button", { name: "Apply Theme" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("option", { name: /Classic ATS/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Apply Theme" }));
+
+    await waitFor(() => expect(mocks.router.refresh).toHaveBeenCalled());
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/resume/update-theme",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ theme_id: "classic_ats" }),
+      }),
+    );
+    expect(screen.getByText("Theme updated to Classic ATS")).toBeInTheDocument();
+
+    fireEvent(window, new Event("resize"));
+  });
+
+  it("supports keyboard selection, pro locked-theme access, resize scaling, and API errors", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      Response.json({ error: "Theme update failed" }, { status: 500 }),
+    );
+    render(
+      <ThemeSelector
+        initialThemeId="bento"
+        initialContent={resumeContent}
+        profile={{ handle: "avery", avatar_url: null }}
+        referralCount={0}
+        isPro={true}
+      />,
+    );
+
+    const listbox = screen.getByRole("listbox", { name: "Theme selection" });
+    fireEvent.keyDown(listbox, { key: "ArrowRight" });
+    expect(screen.getAllByText("Bold Corporate").length).toBeGreaterThan(0);
+    fireEvent.keyDown(listbox, { key: "ArrowLeft" });
+    expect(screen.getAllByText("Bento Grid").length).toBeGreaterThan(0);
+    fireEvent(window, new Event("resize"));
+
+    fireEvent.click(screen.getByRole("option", { name: /Bold Corporate/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Apply Theme" }));
+
+    expect(await screen.findByText("Theme update failed")).toBeInTheDocument();
+  });
+});

--- a/__tests__/unit/components/settings-forms.test.tsx
+++ b/__tests__/unit/components/settings-forms.test.tsx
@@ -150,6 +150,7 @@ describe("PrivacySettingsForm", () => {
 });
 
 describe("ThemeSelector", () => {
+  const originalFetch = globalThis.fetch;
   const originalOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetWidth");
 
   beforeEach(() => {
@@ -165,6 +166,7 @@ describe("ThemeSelector", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    globalThis.fetch = originalFetch;
     if (originalOffsetWidth !== undefined) {
       Object.defineProperty(HTMLElement.prototype, "offsetWidth", originalOffsetWidth);
     } else {

--- a/__tests__/unit/components/settings-forms.test.tsx
+++ b/__tests__/unit/components/settings-forms.test.tsx
@@ -64,11 +64,17 @@ const resumeContent: ResumeContent = {
 };
 
 describe("PrivacySettingsForm", () => {
+  const originalFetch = globalThis.fetch;
+
   beforeEach(() => {
     vi.clearAllMocks();
     globalThis.fetch = vi.fn(async () =>
       Response.json({ success: true }),
     ) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
   });
 
   it("saves each privacy toggle and updates visible status labels", async () => {

--- a/__tests__/unit/components/settings-forms.test.tsx
+++ b/__tests__/unit/components/settings-forms.test.tsx
@@ -144,6 +144,8 @@ describe("PrivacySettingsForm", () => {
 });
 
 describe("ThemeSelector", () => {
+  const originalOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetWidth");
+
   beforeEach(() => {
     vi.clearAllMocks();
     globalThis.fetch = vi.fn(async () =>
@@ -157,6 +159,9 @@ describe("ThemeSelector", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    if (originalOffsetWidth) {
+      Object.defineProperty(HTMLElement.prototype, "offsetWidth", originalOffsetWidth);
+    }
   });
 
   it("prevents locked click selection and applies an unlocked theme", async () => {

--- a/__tests__/unit/components/share-delete-flows.test.tsx
+++ b/__tests__/unit/components/share-delete-flows.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SharePopover, type SharePopoverVariant } from "@/components/SharePopover";
 import { DeleteAccountCard } from "@/components/settings/DeleteAccountCard";
 
@@ -32,6 +32,11 @@ vi.mock("sonner", () => ({
   Toaster: () => null,
 }));
 
+const origClipboard = navigator.clipboard;
+const origShare = navigator.share;
+const origCanShare = navigator.canShare;
+const origWindowOpen = window.open;
+
 function installShareMocks() {
   const writeText = vi.fn(async () => undefined);
   const share = vi.fn(async () => undefined);
@@ -55,6 +60,29 @@ describe("SharePopover", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     installShareMocks();
+  });
+
+  afterEach(() => {
+    if (origClipboard !== undefined) {
+      Object.defineProperty(navigator, "clipboard", { value: origClipboard, configurable: true });
+    } else {
+      delete (navigator as { clipboard?: typeof navigator.clipboard }).clipboard;
+    }
+    if (origShare !== undefined) {
+      Object.defineProperty(navigator, "share", { value: origShare, configurable: true });
+    } else {
+      delete (navigator as { share?: typeof navigator.share }).share;
+    }
+    if (origCanShare !== undefined) {
+      Object.defineProperty(navigator, "canShare", { value: origCanShare, configurable: true });
+    } else {
+      delete (navigator as { canShare?: typeof navigator.canShare }).canShare;
+    }
+    if (origWindowOpen !== undefined) {
+      window.open = origWindowOpen;
+    } else {
+      delete (window as { open?: typeof window.open }).open;
+    }
   });
 
   it("supports native sharing, social share URLs, copy, Escape, and outside close", async () => {

--- a/__tests__/unit/components/share-delete-flows.test.tsx
+++ b/__tests__/unit/components/share-delete-flows.test.tsx
@@ -1,0 +1,253 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SharePopover, type SharePopoverVariant } from "@/components/SharePopover";
+import { DeleteAccountCard } from "@/components/settings/DeleteAccountCard";
+
+const mocks = vi.hoisted(() => ({
+  router: {
+    push: vi.fn(),
+    refresh: vi.fn(),
+  },
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+  signOut: vi.fn(async (options?: { fetchOptions?: { onSuccess?: () => void } }) => {
+    options?.fetchOptions?.onSuccess?.();
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => mocks.router,
+}));
+
+vi.mock("@/lib/auth/client", () => ({
+  signOut: (options?: { fetchOptions?: { onSuccess?: () => void } }) => mocks.signOut(options),
+}));
+
+vi.mock("sonner", () => ({
+  toast: mocks.toast,
+  Toaster: () => null,
+}));
+
+function installShareMocks() {
+  const writeText = vi.fn(async () => undefined);
+  const share = vi.fn(async () => undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+  Object.defineProperty(navigator, "share", {
+    value: share,
+    configurable: true,
+  });
+  Object.defineProperty(navigator, "canShare", {
+    value: vi.fn(() => true),
+    configurable: true,
+  });
+  window.open = vi.fn();
+  return { share, writeText };
+}
+
+describe("SharePopover", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    installShareMocks();
+  });
+
+  it("supports native sharing, social share URLs, copy, Escape, and outside close", async () => {
+    const user = userEvent.setup();
+    const { share, writeText } = installShareMocks();
+    render(
+      <SharePopover
+        url="https://clickfolio.me/@avery"
+        title="Avery Portfolio"
+        name="Avery Quinn"
+        variant="dev-terminal"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /share/i }));
+    await user.click(screen.getByRole("button", { name: "Share this page" }));
+    expect(share).toHaveBeenCalledWith({
+      title: "Avery Portfolio",
+      text: "Check out Avery Quinn's portfolio",
+      url: "https://clickfolio.me/@avery",
+    });
+    expect(screen.queryByRole("dialog", { name: "Share options" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /share/i }));
+    await user.click(screen.getByRole("button", { name: "Share on X (Twitter)" }));
+    expect(window.open).toHaveBeenLastCalledWith(
+      expect.stringContaining("https://twitter.com/intent/tweet?"),
+      "_blank",
+      "noopener,noreferrer",
+    );
+
+    await user.click(screen.getByRole("button", { name: /share/i }));
+    await user.click(screen.getByRole("button", { name: "Share on LinkedIn" }));
+    expect(window.open).toHaveBeenLastCalledWith(
+      expect.stringContaining("https://www.linkedin.com/sharing/share-offsite/"),
+      "_blank",
+      "noopener,noreferrer",
+    );
+
+    await user.click(screen.getByRole("button", { name: /share/i }));
+    await user.click(screen.getByRole("button", { name: "Share on WhatsApp" }));
+    expect(window.open).toHaveBeenLastCalledWith(
+      expect.stringContaining("https://wa.me/?"),
+      "_blank",
+      "noopener,noreferrer",
+    );
+
+    await user.click(screen.getByRole("button", { name: /share/i }));
+    await user.click(screen.getByRole("button", { name: "Copy link" }));
+    expect(writeText).toHaveBeenCalledWith("https://clickfolio.me/@avery");
+    expect(mocks.toast.success).toHaveBeenCalledWith("Link copied!");
+
+    await user.click(screen.getByRole("button", { name: /share/i }));
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog", { name: "Share options" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /share/i }));
+    fireEvent.pointerDown(document.body);
+    expect(screen.queryByRole("dialog", { name: "Share options" })).not.toBeInTheDocument();
+  });
+
+  it("uses handle-based URLs, hides native share when unsupported, and ignores share cancelation", async () => {
+    const user = userEvent.setup();
+    const { writeText } = installShareMocks();
+    Object.defineProperty(navigator, "canShare", {
+      value: undefined,
+      configurable: true,
+    });
+    render(<SharePopover handle="avery" title="Avery" name="" variant="midnight" />);
+
+    await user.click(screen.getByRole("button", { name: /share/i }));
+    expect(screen.queryByRole("button", { name: "Share this page" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Copy link" }));
+    expect(writeText).toHaveBeenCalledWith("http://localhost:3000/@avery");
+
+    const abortError = new Error("cancelled");
+    abortError.name = "AbortError";
+    Object.defineProperty(navigator, "canShare", {
+      value: vi.fn(() => true),
+      configurable: true,
+    });
+    Object.defineProperty(navigator, "share", {
+      value: vi.fn(async () => {
+        throw abortError;
+      }),
+      configurable: true,
+    });
+    render(<SharePopover handle="cancelled" title="Cancel" name="Cancel User" />);
+    await user.click(screen.getAllByRole("button", { name: /share/i }).at(-1) ?? document.body);
+    await user.click(screen.getByRole("button", { name: "Share this page" }));
+    expect(navigator.share).toHaveBeenCalled();
+  });
+
+  it("renders theme variants without dropping share actions", async () => {
+    Object.defineProperty(navigator, "canShare", {
+      value: undefined,
+      configurable: true,
+    });
+    const variants: SharePopoverVariant[] = [
+      "minimalist-editorial",
+      "neo-brutalist",
+      "glass-morphic",
+      "bento-grid",
+      "spotlight",
+      "midnight",
+      "bold-corporate",
+      "classic-ats",
+      "design-folio",
+      "dev-terminal",
+    ];
+
+    for (const variant of variants) {
+      const { unmount } = render(
+        <SharePopover
+          url={`https://clickfolio.me/${variant}`}
+          title={variant}
+          name={variant}
+          variant={variant}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: /share/i }));
+      expect(screen.getByRole("button", { name: "Share on LinkedIn" })).toBeInTheDocument();
+      unmount();
+    }
+  });
+});
+
+describe("DeleteAccountCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+  });
+
+  it("requires an email match, deletes the account, surfaces warnings, and signs out", async () => {
+    const user = userEvent.setup();
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      Response.json({
+        success: true,
+        warnings: [{ type: "r2", message: "Failed to delete file: old.pdf" }],
+      }),
+    );
+
+    render(<DeleteAccountCard userEmail="avery@example.com" />);
+    await user.click(screen.getByRole("button", { name: "Delete Account" }));
+
+    const deleteForever = screen.getByRole("button", { name: /delete forever/i });
+    expect(deleteForever).toBeDisabled();
+    await user.type(screen.getByLabelText(/Type/), "AVERY@EXAMPLE.COM");
+    expect(deleteForever).toBeEnabled();
+    await user.click(deleteForever);
+
+    await waitFor(() => expect(mocks.signOut).toHaveBeenCalled());
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/account/delete",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+        body: JSON.stringify({ confirmation: "AVERY@EXAMPLE.COM" }),
+      }),
+    );
+    expect(mocks.toast.warning).toHaveBeenCalledWith("Warning: Failed to delete file: old.pdf");
+    expect(mocks.toast.success).toHaveBeenCalledWith("Your account has been deleted");
+    expect(mocks.router.push).toHaveBeenCalledWith("/");
+    expect(mocks.router.refresh).toHaveBeenCalled();
+  });
+
+  it("shows API errors, clears state on cancel, and handles network failures", async () => {
+    const user = userEvent.setup();
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(
+        Response.json({ error: "Email confirmation mismatch" }, { status: 400 }),
+      )
+      .mockRejectedValueOnce(new Error("network down"));
+
+    render(<DeleteAccountCard userEmail="avery@example.com" />);
+    await user.click(screen.getByRole("button", { name: "Delete Account" }));
+    await user.type(screen.getByLabelText(/Type/), "avery@example.com");
+    await user.click(screen.getByRole("button", { name: /delete forever/i }));
+
+    expect(await screen.findByText("Email confirmation mismatch")).toBeInTheDocument();
+    expect(mocks.toast.error).toHaveBeenCalledWith("Email confirmation mismatch");
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    await user.click(screen.getByRole("button", { name: "Delete Account" }));
+    expect(screen.getByLabelText(/Type/)).toHaveValue("");
+
+    await user.type(screen.getByLabelText(/Type/), "avery@example.com");
+    await user.click(screen.getByRole("button", { name: /delete forever/i }));
+    expect(
+      await screen.findByText("An unexpected error occurred. Please try again."),
+    ).toBeInTheDocument();
+    expect(mocks.toast.error).toHaveBeenCalledWith(
+      "An unexpected error occurred. Please try again.",
+    );
+  });
+});

--- a/__tests__/unit/components/share-delete-flows.test.tsx
+++ b/__tests__/unit/components/share-delete-flows.test.tsx
@@ -222,32 +222,37 @@ describe("DeleteAccountCard", () => {
   });
 
   it("shows API errors, clears state on cancel, and handles network failures", async () => {
-    const user = userEvent.setup();
-    vi.mocked(globalThis.fetch)
-      .mockResolvedValueOnce(
-        Response.json({ error: "Email confirmation mismatch" }, { status: 400 }),
-      )
-      .mockRejectedValueOnce(new Error("network down"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const user = userEvent.setup();
+      vi.mocked(globalThis.fetch)
+        .mockResolvedValueOnce(
+          Response.json({ error: "Email confirmation mismatch" }, { status: 400 }),
+        )
+        .mockRejectedValueOnce(new Error("network down"));
 
-    render(<DeleteAccountCard userEmail="avery@example.com" />);
-    await user.click(screen.getByRole("button", { name: "Delete Account" }));
-    await user.type(screen.getByLabelText(/Type/), "avery@example.com");
-    await user.click(screen.getByRole("button", { name: /delete forever/i }));
+      render(<DeleteAccountCard userEmail="avery@example.com" />);
+      await user.click(screen.getByRole("button", { name: "Delete Account" }));
+      await user.type(screen.getByLabelText(/Type/), "avery@example.com");
+      await user.click(screen.getByRole("button", { name: /delete forever/i }));
 
-    expect(await screen.findByText("Email confirmation mismatch")).toBeInTheDocument();
-    expect(mocks.toast.error).toHaveBeenCalledWith("Email confirmation mismatch");
+      expect(await screen.findByText("Email confirmation mismatch")).toBeInTheDocument();
+      expect(mocks.toast.error).toHaveBeenCalledWith("Email confirmation mismatch");
 
-    await user.click(screen.getByRole("button", { name: "Cancel" }));
-    await user.click(screen.getByRole("button", { name: "Delete Account" }));
-    expect(screen.getByLabelText(/Type/)).toHaveValue("");
+      await user.click(screen.getByRole("button", { name: "Cancel" }));
+      await user.click(screen.getByRole("button", { name: "Delete Account" }));
+      expect(screen.getByLabelText(/Type/)).toHaveValue("");
 
-    await user.type(screen.getByLabelText(/Type/), "avery@example.com");
-    await user.click(screen.getByRole("button", { name: /delete forever/i }));
-    expect(
-      await screen.findByText("An unexpected error occurred. Please try again."),
-    ).toBeInTheDocument();
-    expect(mocks.toast.error).toHaveBeenCalledWith(
-      "An unexpected error occurred. Please try again.",
-    );
+      await user.type(screen.getByLabelText(/Type/), "avery@example.com");
+      await user.click(screen.getByRole("button", { name: /delete forever/i }));
+      expect(
+        await screen.findByText("An unexpected error occurred. Please try again."),
+      ).toBeInTheDocument();
+      expect(mocks.toast.error).toHaveBeenCalledWith(
+        "An unexpected error occurred. Please try again.",
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/__tests__/unit/components/smoke-render.test.tsx
+++ b/__tests__/unit/components/smoke-render.test.tsx
@@ -201,6 +201,7 @@ const resumeContent: ResumeContent = {
   ],
 };
 
+let _originalsCaptured = false;
 let _origResizeObserver: typeof ResizeObserver | undefined;
 let _origIntersectionObserver: typeof IntersectionObserver | undefined;
 let _origMatchMedia: typeof window.matchMedia | undefined;
@@ -210,13 +211,16 @@ let _origWindowOpen: typeof window.open | undefined;
 let _origWindowConfirm: typeof window.confirm | undefined;
 
 function installBrowserMocks() {
-  _origResizeObserver = _origResizeObserver ?? globalThis.ResizeObserver;
-  _origIntersectionObserver = _origIntersectionObserver ?? globalThis.IntersectionObserver;
-  _origMatchMedia = _origMatchMedia ?? window.matchMedia;
-  _origClipboard = _origClipboard ?? navigator.clipboard;
-  _origShare = _origShare ?? navigator.share;
-  _origWindowOpen = _origWindowOpen ?? window.open;
-  _origWindowConfirm = _origWindowConfirm ?? window.confirm;
+  if (!_originalsCaptured) {
+    _origResizeObserver = globalThis.ResizeObserver;
+    _origIntersectionObserver = globalThis.IntersectionObserver;
+    _origMatchMedia = window.matchMedia;
+    _origClipboard = navigator.clipboard;
+    _origShare = navigator.share;
+    _origWindowOpen = window.open;
+    _origWindowConfirm = window.confirm;
+    _originalsCaptured = true;
+  }
 
   globalThis.ResizeObserver = class {
     callback: ResizeObserverCallback;

--- a/__tests__/unit/components/smoke-render.test.tsx
+++ b/__tests__/unit/components/smoke-render.test.tsx
@@ -266,16 +266,42 @@ function installBrowserMocks() {
 }
 
 afterAll(() => {
-  if (_origResizeObserver) globalThis.ResizeObserver = _origResizeObserver;
-  if (_origIntersectionObserver) globalThis.IntersectionObserver = _origIntersectionObserver;
-  if (_origMatchMedia)
+  if (_origResizeObserver !== undefined) {
+    globalThis.ResizeObserver = _origResizeObserver;
+  } else {
+    delete (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver;
+  }
+  if (_origIntersectionObserver !== undefined) {
+    globalThis.IntersectionObserver = _origIntersectionObserver;
+  } else {
+    delete (globalThis as { IntersectionObserver?: typeof IntersectionObserver })
+      .IntersectionObserver;
+  }
+  if (_origMatchMedia !== undefined) {
     Object.defineProperty(window, "matchMedia", { value: _origMatchMedia, configurable: true });
-  if (_origClipboard)
+  } else {
+    delete (window as { matchMedia?: typeof window.matchMedia }).matchMedia;
+  }
+  if (_origClipboard !== undefined) {
     Object.defineProperty(navigator, "clipboard", { value: _origClipboard, configurable: true });
-  if (_origShare)
+  } else {
+    delete (navigator as { clipboard?: typeof navigator.clipboard }).clipboard;
+  }
+  if (_origShare !== undefined) {
     Object.defineProperty(navigator, "share", { value: _origShare, configurable: true });
-  if (_origWindowOpen) window.open = _origWindowOpen;
-  if (_origWindowConfirm) window.confirm = _origWindowConfirm;
+  } else {
+    delete (navigator as { share?: typeof navigator.share }).share;
+  }
+  if (_origWindowOpen !== undefined) {
+    window.open = _origWindowOpen;
+  } else {
+    delete (window as { open?: typeof window.open }).open;
+  }
+  if (_origWindowConfirm !== undefined) {
+    window.confirm = _origWindowConfirm;
+  } else {
+    delete (window as { confirm?: typeof window.confirm }).confirm;
+  }
 });
 
 describe("component smoke rendering", () => {

--- a/__tests__/unit/components/smoke-render.test.tsx
+++ b/__tests__/unit/components/smoke-render.test.tsx
@@ -380,7 +380,10 @@ describe("component smoke rendering", () => {
       if (url.includes("/api/wizard/complete")) {
         return new Response(JSON.stringify({ success: true }), { status: 200 });
       }
-      return new Response(JSON.stringify({ ok: true, available: true }), { status: 200 });
+      if (url.includes("/api/handle/check")) {
+        return new Response(JSON.stringify({ ok: true, available: true }), { status: 200 });
+      }
+      throw new Error(`Unhandled fetch mock URL: ${url}`);
     }) as unknown as typeof fetch;
   });
 

--- a/__tests__/unit/components/smoke-render.test.tsx
+++ b/__tests__/unit/components/smoke-render.test.tsx
@@ -1,0 +1,625 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Users } from "lucide-react";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AdminAnalyticsPage from "@/app/(admin)/admin/analytics/page";
+import AdminReferralsPage from "@/app/(admin)/admin/referrals/page";
+import AdminResumesPage from "@/app/(admin)/admin/resumes/page";
+import AdminUsersPage from "@/app/(admin)/admin/users/page";
+import WaitingPage from "@/app/(protected)/waiting/page";
+import WizardPage from "@/app/(protected)/wizard/page";
+import VerifyEmailPage from "@/app/(public)/verify-email/page";
+import ResetPasswordPage from "@/app/reset-password/page";
+import { AttributionWidget } from "@/components/AttributionWidget";
+import { AdminHeader } from "@/components/admin/AdminHeader";
+import { AdminSidebar } from "@/components/admin/AdminSidebar";
+import { AdminSparkline } from "@/components/admin/AdminSparkline";
+import { AdminTrafficChart } from "@/components/admin/AdminTrafficChart";
+import { FunnelChart } from "@/components/admin/FunnelChart";
+import { HorizontalBarChart } from "@/components/admin/HorizontalBarChart";
+import { Pagination } from "@/components/admin/Pagination";
+import { ResumeStatusBadge } from "@/components/admin/ResumeStatusBadge";
+import { StatCard } from "@/components/admin/StatCard";
+import { UserStatusBadge } from "@/components/admin/UserStatusBadge";
+import { GoogleButton } from "@/components/auth/GoogleButton";
+import { LoginButton } from "@/components/auth/LoginButton";
+import { PasswordInput } from "@/components/auth/PasswordInput";
+import { PasswordStrengthMeter } from "@/components/auth/PasswordStrengthMeter";
+import { HighlightBlock } from "@/components/blog/HighlightBlock";
+import { StatsGrid } from "@/components/blog/StatsGrid";
+import { Confetti } from "@/components/Confetti";
+import { AnalyticsCard } from "@/components/dashboard/AnalyticsCard";
+import { CopyLinkButton } from "@/components/dashboard/CopyLinkButton";
+import { DashboardUploadSection } from "@/components/dashboard/DashboardUploadSection";
+import { EmailVerificationBanner } from "@/components/dashboard/EmailVerificationBanner";
+import { MilestoneToasts } from "@/components/dashboard/MilestoneToasts";
+import { RealtimeStatusListener } from "@/components/dashboard/RealtimeStatusListener";
+import { ReferralStats } from "@/components/dashboard/ReferralStats";
+import { Sidebar } from "@/components/dashboard/Sidebar";
+import { ThemeSelector } from "@/components/dashboard/ThemeSelector";
+import { EditResumeForm } from "@/components/forms/EditResumeForm";
+import { HandleForm } from "@/components/forms/HandleForm";
+import { PrivacySettingsForm } from "@/components/forms/PrivacySettings";
+import { BottomCTAButton } from "@/components/home/BottomCTAButton";
+import { ExamplesSection } from "@/components/home/ExamplesSection";
+import { FAQSection } from "@/components/home/FAQSection";
+import { MobileStickyUpload } from "@/components/home/MobileStickyUpload";
+import { UsageStats } from "@/components/home/UsageStats";
+import { WhatYouGetSection } from "@/components/home/WhatYouGetSection";
+import { Logo } from "@/components/Logo";
+import { LogoIcon } from "@/components/LogoIcon";
+import { LogoText } from "@/components/LogoText";
+import { RelatedProfiles } from "@/components/RelatedProfiles";
+import { ShareBar } from "@/components/ShareBar";
+import { SharePopover } from "@/components/SharePopover";
+import { DeleteAccountCard } from "@/components/settings/DeleteAccountCard";
+import { ResumeManagementCard } from "@/components/settings/ResumeManagementCard";
+import { RoleSelectorCard } from "@/components/settings/RoleSelectorCard";
+import { TemplatePreviewModal } from "@/components/templates/TemplatePreviewModal";
+import { HandleStep } from "@/components/wizard/HandleStep";
+import { ReviewStep } from "@/components/wizard/ReviewStep";
+import { ThemeStep } from "@/components/wizard/ThemeStep";
+import { UploadStep } from "@/components/wizard/UploadStep";
+import { WizardProgress } from "@/components/wizard/WizardProgress";
+import { YouAreLiveModal } from "@/components/YouAreLiveModal";
+import { DEMO_PROFILES } from "@/lib/templates/demo-data";
+import type { ResumeContent } from "@/lib/types/database";
+
+const mocks = vi.hoisted(() => ({
+  router: {
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+  },
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+  signInSocial: vi.fn().mockResolvedValue({ data: {}, error: null }),
+  signOut: vi.fn().mockResolvedValue(undefined),
+  sessionState: {
+    current: {
+      data: null as { user: { id: string; email: string; name: string } } | null,
+      isPending: false,
+    },
+  },
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => mocks.router,
+  usePathname: () => "/dashboard",
+  useSearchParams: () => new URLSearchParams("resume_id=res_123&token=token_123"),
+}));
+
+vi.mock("@/lib/auth/client", () => ({
+  useSession: () => mocks.sessionState.current,
+  signIn: {
+    social: (...args: unknown[]) => mocks.signInSocial(...args),
+    email: vi.fn().mockResolvedValue({ data: {}, error: null }),
+  },
+  signUp: {
+    email: vi.fn().mockResolvedValue({ data: {}, error: null }),
+  },
+  signOut: (...args: unknown[]) => mocks.signOut(...args),
+  sendVerificationEmail: vi.fn().mockResolvedValue({ data: {}, error: null }),
+  resetPassword: vi.fn().mockResolvedValue({ data: {}, error: null }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: mocks.toast,
+  Toaster: () => null,
+}));
+
+vi.mock("@/hooks/useResumeStatus", () => ({
+  useResumeStatus: () => ({
+    status: "failed",
+    progress: 100,
+    error: "Parsing failed",
+    canRetry: true,
+    isLoading: false,
+    refetch: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock("uplot", () => {
+  class MockUPlot {
+    static paths = { spline: () => undefined };
+    over = document.createElement("div");
+    ctx = {
+      createLinearGradient: () => ({
+        addColorStop: vi.fn(),
+      }),
+    };
+    bbox = { height: 160 };
+    cursor = { idx: null, left: 0, top: 0 };
+    data: unknown[];
+
+    constructor(_opts: unknown, data: unknown[], el: HTMLElement) {
+      this.data = data;
+      el.appendChild(this.over);
+    }
+
+    destroy() {}
+  }
+
+  return { default: MockUPlot };
+});
+
+const resumeContent: ResumeContent = {
+  full_name: "Avery Quinn",
+  headline: "Staff Product Engineer",
+  summary: "Builds reliable products with TypeScript and Cloudflare.",
+  contact: {
+    email: "avery@example.com",
+    phone: "555-0100",
+    location: "Phoenix, AZ",
+    linkedin: "https://linkedin.com/in/avery",
+    github: "https://github.com/avery",
+    website: "https://avery.dev",
+  },
+  experience: [
+    {
+      title: "Staff Engineer",
+      company: "Acme",
+      location: "Remote",
+      start_date: "2022",
+      end_date: "",
+      description: "Led platform delivery.",
+      highlights: ["Improved reliability", "Mentored engineers"],
+    },
+  ],
+  education: [{ degree: "BS CS", institution: "State University", graduation_date: "2018" }],
+  skills: [{ category: "Languages", items: ["TypeScript", "SQL"] }],
+  certifications: [{ name: "Workers", issuer: "Cloudflare", date: "2025" }],
+  projects: [
+    {
+      title: "Portfolio Engine",
+      description: "Generated portfolio sites.",
+      year: "2026",
+      technologies: ["React"],
+      url: "https://example.com",
+    },
+  ],
+};
+
+function installBrowserMocks() {
+  globalThis.ResizeObserver = class {
+    callback: ResizeObserverCallback;
+
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback;
+    }
+
+    observe(target: Element) {
+      this.callback(
+        [{ target, contentRect: { width: 320, height: 160 } } as ResizeObserverEntry],
+        this,
+      );
+    }
+
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+
+  globalThis.IntersectionObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof IntersectionObserver;
+
+  Object.defineProperty(window, "matchMedia", {
+    value: vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+    configurable: true,
+  });
+
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    configurable: true,
+  });
+
+  Object.defineProperty(navigator, "share", {
+    value: vi.fn().mockResolvedValue(undefined),
+    configurable: true,
+  });
+
+  window.open = vi.fn();
+  window.confirm = vi.fn().mockReturnValue(true);
+}
+
+describe("component smoke rendering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.sessionState.current = { data: null, isPending: false };
+    installBrowserMocks();
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/admin/analytics")) {
+        return new Response(
+          JSON.stringify({
+            totals: { views: 1200, unique: 400, avgPerDay: 80, profilesViewed: 55 },
+            changes: { views: 12, unique: 5, avgPerDay: -3 },
+            daily: [{ date: "2026-05-20", views: 50, unique: 20 }],
+            topProfiles: [{ handle: "avery", views: 44 }],
+            referrers: [{ domain: "linkedin.com", count: 20, percent: 50 }],
+            countries: [{ code: "US", name: "United States", percent: 75 }],
+            devices: [{ type: "desktop", percent: 80 }],
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/api/admin/users")) {
+        return new Response(
+          JSON.stringify({
+            users: [
+              {
+                id: "user_1",
+                name: "Avery",
+                email: "avery@example.com",
+                handle: "avery",
+                status: "live",
+                views: 42,
+                createdAt: "2026-05-20T00:00:00Z",
+                isPro: true,
+              },
+            ],
+            total: 1,
+            page: 1,
+            pageSize: 25,
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/api/admin/resumes")) {
+        return new Response(
+          JSON.stringify({
+            stats: { completed: 3, processing: 1, queued: 1, failed: 1 },
+            resumes: [
+              {
+                id: "res_123",
+                userEmail: "avery@example.com",
+                status: "failed",
+                retryCount: 1,
+                totalAttempts: 2,
+                lastAttemptError: "Parse failed",
+                updatedAt: "2026-05-20T00:00:00Z",
+              },
+            ],
+            total: 1,
+            page: 1,
+            pageSize: 25,
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/api/admin/referrals")) {
+        return new Response(
+          JSON.stringify({
+            stats: { totalReferrers: 4, totalClicks: 100, conversions: 20, conversionRate: 20 },
+            funnel: { clicks: 100, unique: 80, signups: 20 },
+            topReferrers: [{ handle: "avery", clicks: 50, conversions: 10, rate: "20%" }],
+            sources: [{ source: "homepage", percent: 60 }],
+            recentConversions: [
+              {
+                newUserEmail: "new@example.com",
+                referrerHandle: "avery",
+                createdAt: "2026-05-20T00:00:00Z",
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/api/analytics/stats")) {
+        return new Response(
+          JSON.stringify({
+            totalViews: 1234,
+            uniqueVisitors: 456,
+            viewsByDay: [{ date: "2026-05-20", views: 12, uniques: 8 }],
+            topReferrers: [{ referrer: "linkedin.com", count: 7 }],
+            directVisits: 5,
+            deviceBreakdown: [{ device: "desktop", count: 10 }],
+            countryBreakdown: [{ country: "US", count: 10 }],
+            period: "7d",
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/api/upload")) {
+        const isPending = url.includes("/api/upload/pending");
+        return new Response(
+          JSON.stringify(
+            isPending
+              ? { key: null, file_hash: null }
+              : { key: "temp/key", remaining: { hourly: 9, daily: 49 } },
+          ),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/api/site-data")) {
+        return new Response(
+          JSON.stringify({ id: "site_1", content: resumeContent, themeId: "minimalist_editorial" }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/api/user/stats")) {
+        return new Response(JSON.stringify({ referralCount: 5, isPro: false }), { status: 200 });
+      }
+      if (url.includes("/api/resume/latest-status")) {
+        return new Response(JSON.stringify({ id: "res_123", status: "completed" }), {
+          status: 200,
+        });
+      }
+      if (url.includes("/api/resume/claim")) {
+        return new Response(JSON.stringify({ resume_id: "res_123", cached: true }), {
+          status: 200,
+        });
+      }
+      if (url.includes("/api/wizard/complete")) {
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ ok: true, available: true }), { status: 200 });
+    }) as unknown as typeof fetch;
+  });
+
+  it("renders standalone brand, share, admin, and dashboard components", async () => {
+    const { rerender } = render(
+      <div>
+        <Logo />
+        <LogoIcon />
+        <LogoText />
+        <AttributionWidget theme="minimalist-editorial" />
+        <Confetti force />
+        <RelatedProfiles profiles={[{ handle: "avery", name: "Avery", headline: "Engineer" }]} />
+        <ShareBar title="Avery portfolio" name="Avery" handle="avery" />
+        <SharePopover title="Avery portfolio" name="Avery" handle="avery" />
+        <YouAreLiveModal
+          open
+          onOpenChange={vi.fn()}
+          handle="avery"
+          url="https://clickfolio.me/@avery"
+        />
+        <AdminHeader onMenuClick={vi.fn()} />
+        <AdminSidebar isOpen onClose={vi.fn()} adminEmail="admin@example.com" />
+        <AdminSparkline
+          data={[
+            { date: "2026-05-17", views: 1 },
+            { date: "2026-05-18", views: 3 },
+            { date: "2026-05-19", views: 2 },
+            { date: "2026-05-20", views: 5 },
+          ]}
+        />
+        <AdminTrafficChart data={[{ date: "2026-05-20", views: 10, unique: 2 }]} />
+        <FunnelChart
+          steps={[
+            { label: "Visit", value: 100 },
+            { label: "Signup", value: 20 },
+          ]}
+        />
+        <HorizontalBarChart items={[{ label: "Google", value: 20, percent: 50 }]} />
+        <Pagination currentPage={2} totalPages={5} onPageChange={vi.fn()} />
+        <ResumeStatusBadge status="completed" />
+        <ResumeStatusBadge status="failed" />
+        <UserStatusBadge status="live" />
+        <StatCard
+          title="Users"
+          value="42"
+          icon={Users}
+          iconColorClass="text-coral"
+          iconBgClass="bg-coral/20"
+          change={10}
+        />
+        <CopyLinkButton handle="avery" />
+        <DashboardUploadSection />
+        <EmailVerificationBanner
+          email="avery@example.com"
+          emailVerified={false}
+          isOAuthUser={false}
+        />
+        <MilestoneToasts totalViews={1000} />
+        <RealtimeStatusListener resumeId="res_123" userId="user_1" currentStatus="processing" />
+        <ReferralStats referralCount={2} clickCount={10} referralCode="ABCD1234" />
+        <Sidebar isOpen onClose={vi.fn()} />
+      </div>,
+    );
+
+    expect(screen.getAllByText("clickfolio").length).toBeGreaterThan(0);
+    expect(screen.getByText("Share Clickfolio")).toBeInTheDocument();
+    expect(screen.getAllByText("Users").length).toBeGreaterThan(0);
+    await userEvent.click(screen.getAllByRole("button", { name: /copy/i })[0]);
+    expect(navigator.clipboard.writeText).toHaveBeenCalled();
+
+    rerender(
+      <ThemeSelector
+        initialThemeId="minimalist_editorial"
+        initialContent={resumeContent}
+        profile={{ handle: "avery", avatar_url: null }}
+        referralCount={10}
+        isPro={false}
+      />,
+    );
+    expect(screen.getByText(/Choose Your Theme/)).toBeInTheDocument();
+  });
+
+  it("auto-cleans confetti after the configured duration", async () => {
+    vi.useFakeTimers();
+    try {
+      const { container } = render(<Confetti duration={1} />);
+      expect(container.firstChild).toBeInTheDocument();
+
+      await act(async () => {
+        vi.advanceTimersByTime(501);
+      });
+
+      expect(container.firstChild).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("renders auth controls and handles Google sign-in", async () => {
+    render(
+      <div>
+        <GoogleButton callbackURL="/wizard" onSuccess={vi.fn()} />
+        <LoginButton />
+        <PasswordInput placeholder="Password" />
+        <PasswordStrengthMeter
+          breachCount={2}
+          result={{
+            score: 2,
+            isAcceptable: false,
+            crackTimeDisplay: "3 hours",
+            crackTimeSeconds: 10_800,
+            feedback: {
+              warning: "Needs more variety",
+              suggestions: ["Add another word"],
+            },
+          }}
+        />
+      </div>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /continue with google/i }));
+    expect(mocks.signInSocial).toHaveBeenCalledWith({ provider: "google", callbackURL: "/wizard" });
+    expect(screen.getByText("Fair")).toBeInTheDocument();
+    expect(screen.getByText(/data breaches/)).toBeInTheDocument();
+  });
+
+  it("renders wizard steps and exercises handle availability", async () => {
+    render(
+      <div>
+        <HandleStep initialHandle="avery" onContinue={vi.fn()} />
+        <ReviewStep content={resumeContent} onContinue={vi.fn()} />
+        <ThemeStep initialTheme="minimalist_editorial" onContinue={vi.fn()} />
+        <UploadStep onContinue={vi.fn()} />
+        <WizardProgress currentStep={2} totalSteps={4} progress={50} />
+      </div>,
+    );
+
+    expect(screen.getByText("Choose Your Handle")).toBeInTheDocument();
+    expect(screen.getByText("Review Your Information")).toBeInTheDocument();
+    expect(screen.getByText("Upload Your Resume")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Your Handle"), { target: { value: "Avery!!" } });
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith("/api/handle/check?handle=avery"));
+  });
+
+  it("renders forms and settings cards with existing resume data", () => {
+    render(
+      <div>
+        <EditResumeForm initialData={resumeContent} onSave={vi.fn().mockResolvedValue(undefined)} />
+        <HandleForm currentHandle="avery" />
+        <HandleForm currentHandle="avery" variant="compact" />
+        <PrivacySettingsForm
+          initialSettings={{
+            show_phone: true,
+            show_address: false,
+            hide_from_search: false,
+            show_in_directory: true,
+          }}
+          userHandle="avery"
+        />
+        <DeleteAccountCard userEmail="avery@example.com" />
+        <ResumeManagementCard
+          resumeCount={2}
+          latestResumeDate="2026-05-20T00:00:00Z"
+          latestResumeStatus="failed"
+          latestResumeError="Parsing failed"
+          latestResumeId="res_123"
+        />
+        <RoleSelectorCard currentRole="senior" roleSource="ai" />
+      </div>,
+    );
+
+    expect(screen.getAllByText("Publish Changes").length).toBeGreaterThan(0);
+    expect(screen.getByText("Privacy")).toBeInTheDocument();
+    expect(screen.getByText("Delete Account")).toBeInTheDocument();
+    expect(screen.getByText("Professional Level")).toBeInTheDocument();
+  });
+
+  it("renders homepage helper sections and template preview modal", () => {
+    render(
+      <div>
+        <BottomCTAButton />
+        <ExamplesSection profiles={DEMO_PROFILES.slice(0, 3)} />
+        <FAQSection />
+        <MobileStickyUpload />
+        <UsageStats />
+        <WhatYouGetSection />
+        <HighlightBlock title="Note">Useful context</HighlightBlock>
+        <StatsGrid stats={[{ label: "Users", value: "1k" }]} />
+        <TemplatePreviewModal isOpen onClose={vi.fn()} selectedIndex={0} onNavigate={vi.fn()} />
+      </div>,
+    );
+
+    expect(screen.getByText("Useful context")).toBeInTheDocument();
+    expect(screen.getByText("What you get")).toBeInTheDocument();
+    expect(screen.getByText("1k")).toBeInTheDocument();
+  });
+
+  it("fetches analytics and renders populated stats", async () => {
+    render(<AnalyticsCard />);
+
+    await waitFor(() => expect(screen.getByText("1.2k")).toBeInTheDocument());
+    expect(screen.getByText("456")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "30d" }));
+    expect(fetch).toHaveBeenCalledWith("/api/analytics/stats?period=30d");
+  });
+
+  it("renders authenticated client route pages", async () => {
+    mocks.sessionState.current = {
+      data: { user: { id: "user_1", email: "avery@example.com", name: "Avery" } },
+      isPending: false,
+    };
+
+    const { rerender } = render(<WizardPage />);
+    await waitFor(() => expect(screen.getByText("Choose Your Handle")).toBeInTheDocument());
+
+    rerender(<WaitingPage />);
+    expect(screen.getByText(/Parsing failed/)).toBeInTheDocument();
+
+    rerender(<VerifyEmailPage />);
+    expect(screen.getByText(/Email Verified/i)).toBeInTheDocument();
+
+    rerender(<ResetPasswordPage />);
+    expect(screen.getAllByText(/Reset Password/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders admin client route pages with loaded API data", async () => {
+    render(
+      <div>
+        <AdminAnalyticsPage />
+        <AdminUsersPage />
+        <AdminResumesPage />
+        <AdminReferralsPage />
+      </div>,
+    );
+
+    await waitFor(() => expect(screen.getByText("Platform Analytics")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("Avery")).toBeInTheDocument());
+    expect(screen.getByText("Referral Program")).toBeInTheDocument();
+    expect(screen.getByText("Parse failed")).toBeInTheDocument();
+  });
+});

--- a/__tests__/unit/components/smoke-render.test.tsx
+++ b/__tests__/unit/components/smoke-render.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event";
 import { Users } from "lucide-react";
 import type React from "react";
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AdminAnalyticsPage from "@/app/(admin)/admin/analytics/page";
 import AdminReferralsPage from "@/app/(admin)/admin/referrals/page";
 import AdminResumesPage from "@/app/(admin)/admin/resumes/page";
@@ -309,6 +309,8 @@ afterAll(() => {
 });
 
 describe("component smoke rendering", () => {
+  const originalFetch = globalThis.fetch;
+
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.sessionState.current = { data: null, isPending: false };
@@ -444,6 +446,10 @@ describe("component smoke rendering", () => {
       }
       throw new Error(`Unhandled fetch mock URL: ${url}`);
     }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
   });
 
   it("renders standalone brand, share, admin, and dashboard components", async () => {

--- a/__tests__/unit/components/smoke-render.test.tsx
+++ b/__tests__/unit/components/smoke-render.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event";
 import { Users } from "lucide-react";
 import type React from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import AdminAnalyticsPage from "@/app/(admin)/admin/analytics/page";
 import AdminReferralsPage from "@/app/(admin)/admin/referrals/page";
 import AdminResumesPage from "@/app/(admin)/admin/resumes/page";
@@ -201,7 +201,23 @@ const resumeContent: ResumeContent = {
   ],
 };
 
+let _origResizeObserver: typeof ResizeObserver | undefined;
+let _origIntersectionObserver: typeof IntersectionObserver | undefined;
+let _origMatchMedia: typeof window.matchMedia | undefined;
+let _origClipboard: typeof navigator.clipboard | undefined;
+let _origShare: typeof navigator.share | undefined;
+let _origWindowOpen: typeof window.open | undefined;
+let _origWindowConfirm: typeof window.confirm | undefined;
+
 function installBrowserMocks() {
+  _origResizeObserver = _origResizeObserver ?? globalThis.ResizeObserver;
+  _origIntersectionObserver = _origIntersectionObserver ?? globalThis.IntersectionObserver;
+  _origMatchMedia = _origMatchMedia ?? window.matchMedia;
+  _origClipboard = _origClipboard ?? navigator.clipboard;
+  _origShare = _origShare ?? navigator.share;
+  _origWindowOpen = _origWindowOpen ?? window.open;
+  _origWindowConfirm = _origWindowConfirm ?? window.confirm;
+
   globalThis.ResizeObserver = class {
     callback: ResizeObserverCallback;
 
@@ -248,6 +264,19 @@ function installBrowserMocks() {
   window.open = vi.fn();
   window.confirm = vi.fn().mockReturnValue(true);
 }
+
+afterAll(() => {
+  if (_origResizeObserver) globalThis.ResizeObserver = _origResizeObserver;
+  if (_origIntersectionObserver) globalThis.IntersectionObserver = _origIntersectionObserver;
+  if (_origMatchMedia)
+    Object.defineProperty(window, "matchMedia", { value: _origMatchMedia, configurable: true });
+  if (_origClipboard)
+    Object.defineProperty(navigator, "clipboard", { value: _origClipboard, configurable: true });
+  if (_origShare)
+    Object.defineProperty(navigator, "share", { value: _origShare, configurable: true });
+  if (_origWindowOpen) window.open = _origWindowOpen;
+  if (_origWindowConfirm) window.confirm = _origWindowConfirm;
+});
 
 describe("component smoke rendering", () => {
   beforeEach(() => {

--- a/__tests__/unit/components/upload-flows.test.tsx
+++ b/__tests__/unit/components/upload-flows.test.tsx
@@ -277,8 +277,12 @@ describe("upload flow components", () => {
     expect(screen.getByText("This resume was already claimed.")).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: "Try Again" }));
+
     await waitFor(() => expect(fetch).toHaveBeenCalledWith("/api/upload", expect.any(Object)));
-    expect(screen.getByText("duplicate.pdf")).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.getByText("This resume was already claimed.")).toBeInTheDocument(),
+    );
   });
 
   it("maps claim status failures and closes modal after authenticated claim success", async () => {

--- a/__tests__/unit/components/upload-flows.test.tsx
+++ b/__tests__/unit/components/upload-flows.test.tsx
@@ -1,0 +1,394 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FileDropzone } from "@/components/FileDropzone";
+import { UploadStep } from "@/components/wizard/UploadStep";
+import type { ResumeContent } from "@/lib/types/database";
+
+const mocks = vi.hoisted(() => ({
+  router: {
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+  },
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+  sessionState: {
+    current: {
+      data: null as { user: { id: string; email: string; name: string } } | null,
+      isPending: false,
+    },
+  },
+  waitResult: {
+    status: "completed" as "completed" | "failed",
+    error: undefined as string | undefined,
+  },
+  clearReferral: vi.fn(),
+  getReferral: vi.fn(() => null as string | null),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => mocks.router,
+}));
+
+vi.mock("@/lib/auth/client", () => ({
+  useSession: () => mocks.sessionState.current,
+  signIn: {
+    social: vi.fn().mockResolvedValue({ data: {}, error: null }),
+    email: vi.fn().mockResolvedValue({ data: {}, error: null }),
+  },
+  signUp: {
+    email: vi.fn().mockResolvedValue({ data: {}, error: null }),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: mocks.toast,
+  Toaster: () => null,
+}));
+
+vi.mock("@/lib/referral", () => ({
+  getStoredReferralCode: () => mocks.getReferral(),
+  clearStoredReferralCode: () => mocks.clearReferral(),
+}));
+
+vi.mock("@/lib/utils/wait-for-completion", () => ({
+  waitForResumeCompletion: vi.fn(async () => mocks.waitResult),
+}));
+
+vi.mock("@/components/auth/AuthDialog", () => ({
+  AuthDialog: ({
+    open,
+    callbackURL,
+  }: {
+    open: boolean;
+    callbackURL: string;
+    onOpenChange: (open: boolean) => void;
+  }) => (open ? <div data-testid="auth-dialog">Auth {callbackURL}</div> : null),
+}));
+
+const resumeContent: ResumeContent = {
+  full_name: "Avery Quinn",
+  headline: "Staff Product Engineer",
+  summary: "Builds reliable products.",
+  contact: { email: "avery@example.com", location: "Phoenix, AZ" },
+  experience: [],
+  education: [],
+  skills: [],
+  certifications: [],
+  projects: [],
+};
+
+function pdfFile(name = "resume.pdf") {
+  return new File(["%PDF-1.4"], name, { type: "application/pdf" });
+}
+
+function installFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  globalThis.fetch = vi.fn((input: RequestInfo | URL, init?: RequestInit) =>
+    Promise.resolve(handler(String(input), init)),
+  ) as unknown as typeof fetch;
+}
+
+function dropFile(file: File) {
+  const dropzone = screen.getByRole("button", {
+    name: /drop your pdf resume here or click to browse files/i,
+  });
+  fireEvent.dragEnter(dropzone, { dataTransfer: { files: [file] } });
+  fireEvent.dragOver(dropzone, { dataTransfer: { files: [file] } });
+  fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
+}
+
+describe("upload flow components", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    sessionStorage.clear();
+    mocks.sessionState.current = { data: null, isPending: false };
+    mocks.waitResult = { status: "completed", error: undefined };
+    mocks.getReferral.mockReturnValue(null);
+  });
+
+  it("rejects invalid files in the public dropzone before hitting upload APIs", () => {
+    render(<FileDropzone />);
+
+    dropFile(new File(["hello"], "resume.txt", { type: "text/plain" }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Only PDF files are allowed");
+    expect(mocks.toast.error).toHaveBeenCalledWith("Only PDF files are allowed");
+  });
+
+  it("uploads an anonymous PDF and opens the auth handoff dialog", async () => {
+    installFetch((url) => {
+      if (url === "/api/upload") {
+        return Response.json({ key: "temp/anon/resume.pdf", remaining: { hourly: 9, daily: 49 } });
+      }
+      if (url === "/api/upload/pending") {
+        return Response.json({ success: true });
+      }
+      return Response.json({ ok: true });
+    });
+
+    render(<FileDropzone />);
+    dropFile(pdfFile());
+
+    await waitFor(() => expect(screen.getByText("Upload Complete!")).toBeInTheDocument());
+    expect(sessionStorage.getItem("temp_upload")).toContain("temp/anon/resume.pdf");
+    expect(mocks.toast.success).toHaveBeenCalledWith("File uploaded successfully!");
+
+    await userEvent.click(screen.getByRole("button", { name: /sign in to publish/i }));
+    expect(screen.getByTestId("auth-dialog")).toHaveTextContent("/wizard");
+
+    await userEvent.click(screen.getByRole("button", { name: /upload a different file/i }));
+    expect(screen.getByText("Drop your PDF here")).toBeInTheDocument();
+  });
+
+  it("supports modal uploads, file picker changes, drag leave, and pending session handoff", async () => {
+    const onOpenChange = vi.fn();
+    mocks.sessionState.current = {
+      data: null,
+      isPending: true,
+    };
+    installFetch((url) => {
+      if (url === "/api/upload") {
+        return Response.json({ key: "temp/modal/resume.pdf", remaining: { hourly: 9, daily: 49 } });
+      }
+      return Response.json({ success: true });
+    });
+
+    render(<FileDropzone open={true} onOpenChange={onOpenChange} />);
+    expect(screen.getByText("Upload New Resume")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Upload anonymously. No account needed until you publish."),
+    ).not.toBeInTheDocument();
+
+    const dropzone = screen.getByRole("button", {
+      name: /drop your pdf resume here or click to browse files/i,
+    });
+    fireEvent.dragEnter(dropzone, { dataTransfer: { files: [pdfFile("modal.pdf")] } });
+    fireEvent.dragLeave(dropzone, { dataTransfer: { files: [] } });
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [pdfFile("picker.pdf")] } });
+
+    await waitFor(() => expect(screen.getByText("Upload Complete!")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /sign in to publish/i })).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("maps upload failures from responses, thrown statuses, and network errors", async () => {
+    installFetch((url) => {
+      if (url === "/api/upload") {
+        return Response.json({ error: "Server rejected upload" }, { status: 500 });
+      }
+      return Response.json({ success: true });
+    });
+    const { unmount } = render(<FileDropzone />);
+    dropFile(pdfFile("server.pdf"));
+    expect(await screen.findByText("Server rejected upload")).toBeInTheDocument();
+    unmount();
+
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input) === "/api/upload") {
+        throw new Response(null, { status: 413 });
+      }
+      return Response.json({ success: true });
+    }) as unknown as typeof fetch;
+    const tooLarge = render(<FileDropzone />);
+    dropFile(pdfFile("large.pdf"));
+    expect(await screen.findByText(/File too large/)).toBeInTheDocument();
+    tooLarge.unmount();
+
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input) === "/api/upload") {
+        throw new Response(null, { status: 401 });
+      }
+      return Response.json({ success: true });
+    }) as unknown as typeof fetch;
+    const expired = render(<FileDropzone />);
+    dropFile(pdfFile("expired.pdf"));
+    expect(await screen.findByText("Session expired. Please sign in again.")).toBeInTheDocument();
+    expired.unmount();
+
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input) === "/api/upload") {
+        throw new Error("Network offline");
+      }
+      return Response.json({ success: true });
+    }) as unknown as typeof fetch;
+    render(<FileDropzone />);
+    dropFile(pdfFile("network.pdf"));
+    expect(await screen.findByText("Network error. Check your connection.")).toBeInTheDocument();
+  });
+
+  it("auto-claims authenticated public uploads and navigates to the dashboard", async () => {
+    mocks.sessionState.current = {
+      data: { user: { id: "user_1", email: "avery@example.com", name: "Avery" } },
+      isPending: false,
+    };
+    mocks.getReferral.mockReturnValue("REF123");
+
+    installFetch((url, init) => {
+      if (url === "/api/upload") {
+        return Response.json({ key: "temp/auth/resume.pdf", remaining: { hourly: 9, daily: 49 } });
+      }
+      if (url === "/api/resume/claim") {
+        expect(init?.body).toContain("REF123");
+        return Response.json({ resume_id: "res_1" });
+      }
+      return Response.json({ success: true });
+    });
+
+    render(<FileDropzone />);
+    dropFile(pdfFile("auth.pdf"));
+
+    await waitFor(() =>
+      expect(mocks.toast.success).toHaveBeenCalledWith(
+        "Resume claimed successfully! Processing...",
+      ),
+    );
+    expect(mocks.clearReferral).toHaveBeenCalled();
+    await waitFor(() => expect(mocks.router.replace).toHaveBeenCalledWith("/dashboard"));
+    expect(mocks.router.refresh).toHaveBeenCalled();
+  });
+
+  it("surfaces claim errors and lets users reset the public dropzone", async () => {
+    mocks.sessionState.current = {
+      data: { user: { id: "user_1", email: "avery@example.com", name: "Avery" } },
+      isPending: false,
+    };
+
+    installFetch((url) => {
+      if (url === "/api/upload") {
+        return Response.json({ key: "temp/auth/resume.pdf", remaining: { hourly: 9, daily: 49 } });
+      }
+      if (url === "/api/resume/claim") {
+        return Response.json({ error: "This resume was already claimed." }, { status: 409 });
+      }
+      return Response.json({ success: true });
+    });
+
+    render(<FileDropzone />);
+    dropFile(pdfFile("duplicate.pdf"));
+
+    await waitFor(() =>
+      expect(screen.getByText("This resume was already claimed.")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("This resume was already claimed.")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Try Again" }));
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith("/api/upload", expect.any(Object)));
+    expect(screen.getByText("duplicate.pdf")).toBeInTheDocument();
+  });
+
+  it("maps claim status failures and closes modal after authenticated claim success", async () => {
+    const onOpenChange = vi.fn();
+    mocks.sessionState.current = {
+      data: { user: { id: "user_1", email: "avery@example.com", name: "Avery" } },
+      isPending: false,
+    };
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/upload") {
+        return Response.json({ key: "temp/auth/missing.pdf", remaining: { hourly: 9, daily: 49 } });
+      }
+      if (url === "/api/resume/claim") {
+        throw new Response(null, { status: 404 });
+      }
+      return Response.json({ success: true });
+    }) as unknown as typeof fetch;
+
+    const { unmount } = render(<FileDropzone />);
+    dropFile(pdfFile("missing.pdf"));
+    expect(
+      await screen.findByText("Upload not found. Please try uploading again."),
+    ).toBeInTheDocument();
+    unmount();
+
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/upload") {
+        return Response.json({ key: "temp/auth/modal.pdf", remaining: { hourly: 9, daily: 49 } });
+      }
+      if (url === "/api/resume/claim") {
+        return Response.json({ resume_id: "res_modal" });
+      }
+      return Response.json({ success: true });
+    }) as unknown as typeof fetch;
+
+    render(<FileDropzone open={true} onOpenChange={onOpenChange} />);
+    dropFile(pdfFile("modal-claim.pdf"));
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+    await waitFor(() => expect(mocks.router.replace).toHaveBeenCalledWith("/dashboard"));
+  });
+
+  it("uploads cached wizard resumes and continues with parsed site data", async () => {
+    const onContinue = vi.fn();
+    installFetch((url) => {
+      if (url === "/api/upload") {
+        return Response.json({ key: "temp/wizard/resume.pdf", remaining: 9 });
+      }
+      if (url === "/api/resume/claim") {
+        return Response.json({ resume_id: "res_1", cached: true });
+      }
+      if (url === "/api/site-data") {
+        return Response.json({ content: resumeContent });
+      }
+      return Response.json({ ok: true });
+    });
+
+    render(<UploadStep onContinue={onContinue} />);
+    dropFile(pdfFile("cached.pdf"));
+
+    await waitFor(() => expect(onContinue).toHaveBeenCalledWith(resumeContent));
+    expect(mocks.clearReferral).toHaveBeenCalled();
+    expect(mocks.toast.success).toHaveBeenCalledWith("Resume parsed successfully!");
+  });
+
+  it("shows wizard upload errors and retry state", async () => {
+    installFetch((url) => {
+      if (url === "/api/upload") {
+        return Response.json({ message: "Too many upload attempts" }, { status: 429 });
+      }
+      return Response.json({ ok: true });
+    });
+
+    render(<UploadStep onContinue={vi.fn()} />);
+    dropFile(pdfFile("rate-limited.pdf"));
+
+    await waitFor(() => expect(screen.getByText("Something Went Wrong")).toBeInTheDocument());
+    expect(screen.getByText("Too many upload attempts")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Try Again" }));
+    expect(screen.getByText("Drop your PDF resume here")).toBeInTheDocument();
+  });
+
+  it("handles non-cached wizard parsing completion and failure", async () => {
+    const onContinue = vi.fn();
+    installFetch((url) => {
+      if (url === "/api/upload") {
+        return Response.json({ key: "temp/wizard/live.pdf", remaining: 9 });
+      }
+      if (url === "/api/resume/claim") {
+        return Response.json({ resume_id: "res_live", cached: false });
+      }
+      if (url === "/api/site-data") {
+        return Response.json({ content: resumeContent });
+      }
+      return Response.json({ ok: true });
+    });
+
+    const { unmount } = render(<UploadStep onContinue={onContinue} />);
+    dropFile(pdfFile("live.pdf"));
+    await waitFor(() => expect(onContinue).toHaveBeenCalledWith(resumeContent));
+    unmount();
+
+    mocks.waitResult = { status: "failed", error: "Parser failed" };
+    onContinue.mockClear();
+    render(<UploadStep onContinue={onContinue} />);
+    dropFile(pdfFile("failed.pdf"));
+
+    await waitFor(() => expect(screen.getByText("Parser failed")).toBeInTheDocument());
+    expect(onContinue).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/components/upload-flows.test.tsx
+++ b/__tests__/unit/components/upload-flows.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FileDropzone } from "@/components/FileDropzone";
 import { UploadStep } from "@/components/wizard/UploadStep";
 import type { ResumeContent } from "@/lib/types/database";
@@ -101,6 +101,8 @@ function dropFile(file: File) {
 }
 
 describe("upload flow components", () => {
+  const originalFetch = globalThis.fetch;
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useRealTimers();
@@ -108,6 +110,10 @@ describe("upload flow components", () => {
     mocks.sessionState.current = { data: null, isPending: false };
     mocks.waitResult = { status: "completed", error: undefined };
     mocks.getReferral.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
   });
 
   it("rejects invalid files in the public dropzone before hitting upload APIs", () => {

--- a/__tests__/unit/lib/ai-index.test.ts
+++ b/__tests__/unit/lib/ai-index.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { parseResumeWithAi } from "@/lib/ai";
+
+const mocks = vi.hoisted(() => ({
+  extractPdfText: vi.fn(),
+  parseWithAi: vi.fn(),
+}));
+
+vi.mock("@/lib/ai/pdf-extract", () => ({
+  extractPdfText: (...args: unknown[]) => mocks.extractPdfText(...args),
+}));
+
+vi.mock("@/lib/ai/ai-parser", () => ({
+  parseWithAi: (...args: unknown[]) => mocks.parseWithAi(...args),
+}));
+
+const validAiData = {
+  full_name: "Avery Quinn",
+  headline: "Staff Engineer",
+  summary: "Builds reliable products.",
+  contact: {
+    email: " AVERY@EXAMPLE.COM ",
+    linkedin: "javascript:alert(1)",
+    github: "https://github.com/avery",
+    website: "https://avery.dev",
+  },
+  experience: [
+    {
+      title: "Lead Engineer",
+      company: "Acme",
+      start_date: "2020",
+      end_date: "Present",
+      description: "Built systems.",
+    },
+  ],
+  professional_level: "senior",
+};
+
+describe("parseResumeWithAi", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.extractPdfText.mockResolvedValue({
+      success: true,
+      text: "Avery Quinn\n\nStaff Engineer",
+    });
+    mocks.parseWithAi.mockResolvedValue({
+      success: true,
+      data: structuredClone(validAiData),
+      structuredOutput: true,
+    });
+  });
+
+  it("returns extraction, empty-text, AI parse, and thrown errors without parsing content", async () => {
+    mocks.extractPdfText.mockResolvedValueOnce({ success: false, error: "PDF failed" });
+    await expect(parseResumeWithAi(new ArrayBuffer(1), {})).resolves.toMatchObject({
+      success: false,
+      error: "PDF failed",
+    });
+
+    mocks.extractPdfText.mockResolvedValueOnce({ success: true, text: " \n\t " });
+    await expect(parseResumeWithAi(new ArrayBuffer(1), {})).resolves.toMatchObject({
+      success: false,
+      error: "Extracted resume text is empty",
+    });
+
+    mocks.parseWithAi.mockResolvedValueOnce({ success: false, error: "AI failed" });
+    await expect(parseResumeWithAi(new ArrayBuffer(1), {})).resolves.toMatchObject({
+      success: false,
+      error: "AI failed",
+    });
+
+    mocks.extractPdfText.mockRejectedValueOnce(new Error("boom"));
+    await expect(parseResumeWithAi(new ArrayBuffer(1), {})).resolves.toMatchObject({
+      success: false,
+      error: "boom",
+    });
+  });
+
+  it("normalizes long resume text and validates structured AI output with safe defaults", async () => {
+    mocks.extractPdfText.mockResolvedValueOnce({
+      success: true,
+      text: `Avery\r\n${" ".repeat(4)}Quinn\n\n\n${"x".repeat(70000)}`,
+    });
+
+    const result = await parseResumeWithAi(new ArrayBuffer(1), { CF_AI_GATEWAY_ID: "gateway" });
+
+    expect(result.success).toBe(true);
+    expect(result.professionalLevel).toBe("senior");
+    expect(mocks.parseWithAi.mock.calls[0][0]).toContain("...[truncated]...");
+    const parsed = JSON.parse(result.parsedContent);
+    expect(parsed.professional_level).toBeUndefined();
+    expect(parsed.contact.email).toBe("avery@example.com");
+    expect(parsed.contact.linkedin).toBeUndefined();
+    expect(parsed.experience[0].end_date).toBeUndefined();
+    expect(parsed.education).toBeUndefined();
+    expect(parsed.skills).toBeUndefined();
+  });
+
+  it("retries invalid AI output with validation feedback and reports final validation failure", async () => {
+    mocks.parseWithAi
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          full_name: "",
+          headline: "",
+          summary: "",
+          contact: { email: "bad" },
+          experience: [],
+        },
+        structuredOutput: true,
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: structuredClone(validAiData),
+        structuredOutput: false,
+      });
+
+    await expect(parseResumeWithAi(new ArrayBuffer(1), {})).resolves.toMatchObject({
+      success: true,
+    });
+    expect(mocks.parseWithAi).toHaveBeenLastCalledWith(
+      expect.any(String),
+      {},
+      undefined,
+      expect.objectContaining({
+        previousOutput: expect.stringContaining("full_name"),
+        errors: expect.stringContaining("Full name is required"),
+      }),
+    );
+
+    mocks.parseWithAi
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          full_name: "",
+          headline: "",
+          summary: "",
+          contact: { email: "bad" },
+          experience: [],
+        },
+        structuredOutput: true,
+      })
+      .mockResolvedValueOnce({
+        success: false,
+        error: "retry failed",
+      });
+
+    await expect(parseResumeWithAi(new ArrayBuffer(1), {})).resolves.toMatchObject({
+      success: false,
+      error: "AI response failed schema validation",
+    });
+  });
+});

--- a/__tests__/unit/lib/auth-client.test.ts
+++ b/__tests__/unit/lib/auth-client.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   requestPasswordReset,
   resetPassword,
@@ -30,8 +30,15 @@ vi.mock("better-auth/react", () => ({
 }));
 
 describe("auth client helpers", () => {
+  const originalFetch = global.fetch;
+
   beforeEach(() => {
     global.fetch = vi.fn() as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.clearAllMocks();
   });
 
   it("creates the Better Auth client with the browser origin and re-exports auth helpers", () => {

--- a/__tests__/unit/lib/auth-client.test.ts
+++ b/__tests__/unit/lib/auth-client.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  requestPasswordReset,
+  resetPassword,
+  sendVerificationEmail,
+  signIn,
+  signOut,
+  signUp,
+  useSession,
+} from "@/lib/auth/client";
+
+const mocks = vi.hoisted(() => {
+  const authClient = {
+    signIn: { email: vi.fn(), social: vi.fn() },
+    signUp: { email: vi.fn() },
+    signOut: vi.fn(),
+    resetPassword: vi.fn(),
+    useSession: vi.fn(),
+    sendVerificationEmail: vi.fn(),
+  };
+
+  return {
+    authClient,
+    createAuthClient: vi.fn((_config: unknown) => authClient),
+  };
+});
+
+vi.mock("better-auth/react", () => ({
+  createAuthClient: (config: unknown) => mocks.createAuthClient(config),
+}));
+
+describe("auth client helpers", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn() as unknown as typeof fetch;
+  });
+
+  it("creates the Better Auth client with the browser origin and re-exports auth helpers", () => {
+    expect(mocks.createAuthClient).toHaveBeenCalledWith({ baseURL: "http://localhost:3000" });
+    expect(signIn).toBe(mocks.authClient.signIn);
+    expect(signUp).toBe(mocks.authClient.signUp);
+    expect(signOut).toBe(mocks.authClient.signOut);
+    expect(resetPassword).toBe(mocks.authClient.resetPassword);
+    expect(useSession).toBe(mocks.authClient.useSession);
+    expect(sendVerificationEmail).toBe(mocks.authClient.sendVerificationEmail);
+  });
+
+  it("returns password reset success data", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(Response.json({ message: "Check your inbox" }));
+
+    await expect(
+      requestPasswordReset({ email: "avery@example.com", redirectTo: "/reset-password" }),
+    ).resolves.toEqual({
+      data: { message: "Check your inbox" },
+      error: null,
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:3000/api/auth/request-password-reset",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: "avery@example.com",
+          redirectTo: "/reset-password",
+        }),
+      }),
+    );
+  });
+
+  it("returns API error messages and status fallbacks", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(Response.json({ message: "No account found" }, { status: 404 }))
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: vi.fn(async () => {
+          throw new Error("invalid json");
+        }),
+      } as unknown as Response);
+
+    const missing = await requestPasswordReset({ email: "missing@example.com" });
+    expect(missing.data).toBeNull();
+    expect(missing.error?.message).toBe("No account found");
+
+    const unavailable = await requestPasswordReset({ email: "avery@example.com" });
+    expect(unavailable.data).toBeNull();
+    expect(unavailable.error?.message).toBe("Request failed with status 503");
+  });
+
+  it("normalizes thrown password reset failures", async () => {
+    vi.mocked(fetch)
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockRejectedValueOnce("blocked");
+
+    const network = await requestPasswordReset({ email: "avery@example.com" });
+    expect(network.data).toBeNull();
+    expect(network.error?.message).toBe("network down");
+
+    const unknown = await requestPasswordReset({ email: "avery@example.com" });
+    expect(unknown.data).toBeNull();
+    expect(unknown.error?.message).toBe("Unknown error");
+  });
+});

--- a/__tests__/unit/lib/auth-index.test.ts
+++ b/__tests__/unit/lib/auth-index.test.ts
@@ -143,41 +143,46 @@ describe("server auth configuration", () => {
   });
 
   it("runs signup and email hooks with disposable, referral, and mail failure branches", async () => {
-    const { getAuth } = await import("@/lib/auth");
-    const auth = await getAuth();
-    const config = auth.config;
-    const beforeCreate = config.databaseHooks.user.create.before;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { getAuth } = await import("@/lib/auth");
+      const auth = await getAuth();
+      const config = auth.config;
+      const beforeCreate = config.databaseHooks.user.create.before;
 
-    await expect(beforeCreate({ email: "temp@example.com" })).resolves.toEqual({
-      data: { email: "temp@example.com", referralCode: "REF123" },
-    });
+      await expect(beforeCreate({ email: "temp@example.com" })).resolves.toEqual({
+        data: { email: "temp@example.com", referralCode: "REF123" },
+      });
 
-    mocks.isDisposableEmail.mockResolvedValueOnce({ disposable: true });
-    await expect(beforeCreate({ email: "blocked@example.com" })).rejects.toBeInstanceOf(
-      mocks.APIError,
-    );
+      mocks.isDisposableEmail.mockResolvedValueOnce({ disposable: true });
+      await expect(beforeCreate({ email: "blocked@example.com" })).rejects.toBeInstanceOf(
+        mocks.APIError,
+      );
 
-    mocks.isDisposableEmail.mockRejectedValueOnce(new Error("kv down"));
-    mocks.generateReferralCode.mockImplementationOnce(() => {
-      throw new Error("rng down");
-    });
-    await expect(beforeCreate({ email: "fallback@example.com" })).resolves.toEqual({
-      data: { email: "fallback@example.com" },
-    });
+      mocks.isDisposableEmail.mockRejectedValueOnce(new Error("kv down"));
+      mocks.generateReferralCode.mockImplementationOnce(() => {
+        throw new Error("rng down");
+      });
+      await expect(beforeCreate({ email: "fallback@example.com" })).resolves.toEqual({
+        data: { email: "fallback@example.com" },
+      });
 
-    mocks.sendPasswordResetEmail.mockResolvedValueOnce({ success: false, error: "mail down" });
-    await config.emailAndPassword.sendResetPassword({
-      user: { email: "avery@example.com", name: "Avery" },
-      url: "https://clickfolio.me/reset",
-    });
+      mocks.sendPasswordResetEmail.mockResolvedValueOnce({ success: false, error: "mail down" });
+      await config.emailAndPassword.sendResetPassword({
+        user: { email: "avery@example.com", name: "Avery" },
+        url: "https://clickfolio.me/reset",
+      });
 
-    mocks.sendVerificationEmail.mockResolvedValueOnce({ success: false, error: "mail down" });
-    await config.emailVerification.sendVerificationEmail({
-      user: { email: "avery@example.com", name: "Avery" },
-      url: "https://clickfolio.me/verify",
-    });
+      mocks.sendVerificationEmail.mockResolvedValueOnce({ success: false, error: "mail down" });
+      await config.emailVerification.sendVerificationEmail({
+        user: { email: "avery@example.com", name: "Avery" },
+        url: "https://clickfolio.me/verify",
+      });
 
-    expect(mocks.sendPasswordResetEmail).toHaveBeenCalled();
-    expect(mocks.sendVerificationEmail).toHaveBeenCalled();
+      expect(mocks.sendPasswordResetEmail).toHaveBeenCalled();
+      expect(mocks.sendVerificationEmail).toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/__tests__/unit/lib/auth-index.test.ts
+++ b/__tests__/unit/lib/auth-index.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type EmailSendResult = {
+  success: boolean;
+  error?: string;
+};
+
+const mocks = vi.hoisted(() => {
+  class APIError extends Error {
+    status: string;
+
+    constructor(status: string, init: { message: string }) {
+      super(init.message);
+      this.status = status;
+    }
+  }
+
+  const env = {
+    CLICKFOLIO_DB: {
+      prepare: vi.fn(() => ({
+        bind: vi.fn((...args: unknown[]) => ({ args })),
+        first: vi.fn(),
+      })),
+    },
+    BETTER_AUTH_URL: "https://clickfolio.me",
+    BETTER_AUTH_SECRET: "secret",
+    GOOGLE_CLIENT_ID: "google-id",
+    GOOGLE_CLIENT_SECRET: "google-secret",
+    CLICKFOLIO_DISPOSABLE_DOMAINS: {},
+  };
+
+  return {
+    APIError,
+    env,
+    betterAuth: vi.fn((config: unknown) => ({ config, handler: vi.fn() })),
+    drizzleAdapter: vi.fn((db: unknown, config: unknown) => ({ db, config })),
+    drizzle: vi.fn((db: unknown, config: unknown) => ({ db, config })),
+    isDisposableEmail: vi.fn(async (_email: string) => ({ disposable: false })),
+    generateReferralCode: vi.fn(() => "REF123"),
+    sendPasswordResetEmail: vi.fn(async (): Promise<EmailSendResult> => ({ success: true })),
+    sendVerificationEmail: vi.fn(async (): Promise<EmailSendResult> => ({ success: true })),
+  };
+});
+
+vi.mock("cloudflare:workers", () => ({
+  env: mocks.env,
+}));
+
+vi.mock("better-auth", () => ({
+  betterAuth: (config: unknown) => mocks.betterAuth(config),
+}));
+
+vi.mock("better-auth/api", () => ({
+  APIError: mocks.APIError,
+}));
+
+vi.mock("@better-auth/drizzle-adapter", () => ({
+  drizzleAdapter: (db: unknown, config: unknown) => mocks.drizzleAdapter(db, config),
+}));
+
+vi.mock("drizzle-orm/d1", () => ({
+  drizzle: (db: unknown, config: unknown) => mocks.drizzle(db, config),
+}));
+
+vi.mock("@/lib/email/cloudflare", () => ({
+  createEmailSender: () => ({
+    sendPasswordResetEmail: mocks.sendPasswordResetEmail,
+    sendVerificationEmail: mocks.sendVerificationEmail,
+  }),
+}));
+
+vi.mock("@/lib/email/disposable-check", () => ({
+  isDisposableEmail: (email: string) => mocks.isDisposableEmail(email),
+}));
+
+vi.mock("@/lib/utils/referral-code", () => ({
+  generateReferralCode: () => mocks.generateReferralCode(),
+}));
+
+describe("server auth configuration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    const mutableEnv = process.env as Record<string, string | undefined>;
+    mutableEnv.NODE_ENV = "test";
+    delete mutableEnv.BETTER_AUTH_SECRET;
+  });
+
+  it("reads environment values from bindings, process fallback, and throws when missing", async () => {
+    const { getEnvValue } = await import("@/lib/auth");
+
+    expect(getEnvValue({ BETTER_AUTH_URL: " https://local.test " }, "BETTER_AUTH_URL")).toBe(
+      " https://local.test ",
+    );
+    process.env.BETTER_AUTH_SECRET = "process-secret";
+    expect(getEnvValue({}, "BETTER_AUTH_SECRET")).toBe("process-secret");
+    expect(() => getEnvValue({}, "GOOGLE_CLIENT_ID")).toThrow(
+      "Missing required environment variable",
+    );
+  });
+
+  it("builds and caches Better Auth while serializing D1 Date binds", async () => {
+    const { getAuth } = await import("@/lib/auth");
+
+    const first = await getAuth();
+    const second = await getAuth();
+
+    expect(first).toBe(second);
+    expect(mocks.betterAuth).toHaveBeenCalledTimes(1);
+    expect(mocks.drizzleAdapter).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ provider: "sqlite" }),
+    );
+
+    const wrappedD1 = mocks.drizzle.mock.calls[0][0] as D1Database;
+    const stmt = wrappedD1.prepare("select ?");
+    expect(stmt.bind(new Date("2026-05-20T00:00:00.000Z"), "x")).toEqual({
+      args: ["2026-05-20T00:00:00.000Z", "x"],
+    });
+  });
+
+  it("runs signup and email hooks with disposable, referral, and mail failure branches", async () => {
+    const { getAuth } = await import("@/lib/auth");
+    const auth = await getAuth();
+    const config = auth.config;
+    const beforeCreate = config.databaseHooks.user.create.before;
+
+    await expect(beforeCreate({ email: "temp@example.com" })).resolves.toEqual({
+      data: { email: "temp@example.com", referralCode: "REF123" },
+    });
+
+    mocks.isDisposableEmail.mockResolvedValueOnce({ disposable: true });
+    await expect(beforeCreate({ email: "blocked@example.com" })).rejects.toBeInstanceOf(
+      mocks.APIError,
+    );
+
+    mocks.isDisposableEmail.mockRejectedValueOnce(new Error("kv down"));
+    mocks.generateReferralCode.mockImplementationOnce(() => {
+      throw new Error("rng down");
+    });
+    await expect(beforeCreate({ email: "fallback@example.com" })).resolves.toEqual({
+      data: { email: "fallback@example.com" },
+    });
+
+    mocks.sendPasswordResetEmail.mockResolvedValueOnce({ success: false, error: "mail down" });
+    await config.emailAndPassword.sendResetPassword({
+      user: { email: "avery@example.com", name: "Avery" },
+      url: "https://clickfolio.me/reset",
+    });
+
+    mocks.sendVerificationEmail.mockResolvedValueOnce({ success: false, error: "mail down" });
+    await config.emailVerification.sendVerificationEmail({
+      user: { email: "avery@example.com", name: "Avery" },
+      url: "https://clickfolio.me/verify",
+    });
+
+    expect(mocks.sendPasswordResetEmail).toHaveBeenCalled();
+    expect(mocks.sendVerificationEmail).toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/lib/auth-index.test.ts
+++ b/__tests__/unit/lib/auth-index.test.ts
@@ -1,9 +1,25 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type EmailSendResult = {
   success: boolean;
   error?: string;
 };
+
+const originalEnv = {
+  BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
+  GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+  NODE_ENV: process.env.NODE_ENV,
+};
+
+function restoreEnv(key: keyof typeof originalEnv) {
+  const mutableEnv = process.env as Record<string, string | undefined>;
+  const value = originalEnv[key];
+  if (value === undefined) {
+    delete mutableEnv[key];
+    return;
+  }
+  mutableEnv[key] = value;
+}
 
 const mocks = vi.hoisted(() => {
   class APIError extends Error {
@@ -84,6 +100,13 @@ describe("server auth configuration", () => {
     const mutableEnv = process.env as Record<string, string | undefined>;
     mutableEnv.NODE_ENV = "test";
     delete mutableEnv.BETTER_AUTH_SECRET;
+    delete mutableEnv.GOOGLE_CLIENT_ID;
+  });
+
+  afterEach(() => {
+    restoreEnv("BETTER_AUTH_SECRET");
+    restoreEnv("GOOGLE_CLIENT_ID");
+    restoreEnv("NODE_ENV");
   });
 
   it("reads environment values from bindings, process fallback, and throws when missing", async () => {

--- a/__tests__/unit/lib/queue/errors.test.ts
+++ b/__tests__/unit/lib/queue/errors.test.ts
@@ -4,7 +4,7 @@ import {
   isRetryableError,
   QueueError,
   QueueErrorType,
-} from "../../../../lib/queue/errors";
+} from "@/lib/queue/errors";
 
 describe("queue error handling", () => {
   describe("QueueError.toJSON()", () => {

--- a/__tests__/unit/lib/queue/errors.test.ts
+++ b/__tests__/unit/lib/queue/errors.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { classifyQueueError, QueueError, QueueErrorType } from "../../../../lib/queue/errors";
+import {
+  classifyQueueError,
+  isRetryableError,
+  QueueError,
+  QueueErrorType,
+} from "../../../../lib/queue/errors";
 
 describe("queue error handling", () => {
   describe("QueueError.toJSON()", () => {
@@ -56,6 +61,92 @@ describe("queue error handling", () => {
 
       expect(error.type).toBe(QueueErrorType.DB_CONNECTION_ERROR);
       expect(error.isRetryable()).toBe(true);
+    });
+
+    it.each([
+      ["database unavailable", QueueErrorType.DB_CONNECTION_ERROR],
+      ["db timeout while opening transaction", QueueErrorType.DB_CONNECTION_ERROR],
+      ["deadline exceeded in worker timeout", QueueErrorType.SERVICE_BINDING_TIMEOUT],
+      ["request took too long and exceeded time limit", QueueErrorType.SERVICE_BINDING_TIMEOUT],
+      ["R2 throttle: too many requests 429", QueueErrorType.R2_THROTTLE],
+      ["R2 service temporarily unavailable", QueueErrorType.R2_THROTTLE],
+      ["not a pdf and cannot parse pdf", QueueErrorType.INVALID_PDF],
+      ["encrypted pdf password protected", QueueErrorType.INVALID_PDF],
+      ["extracted resume text is empty", QueueErrorType.INVALID_PDF],
+      ["NoObjectGeneratedError from provider", QueueErrorType.AI_PROVIDER_ERROR],
+      ["API request failed with provider error", QueueErrorType.AI_PROVIDER_ERROR],
+      ["model unavailable due to insufficient credits", QueueErrorType.AI_PROVIDER_ERROR],
+      ["HTTP 502 bad gateway service unavailable", QueueErrorType.AI_PROVIDER_ERROR],
+      ["invalid json unexpected token", QueueErrorType.MALFORMED_RESPONSE],
+      ["invalid json response from ai", QueueErrorType.MALFORMED_RESPONSE],
+      ["ai parsing failed", QueueErrorType.MALFORMED_RESPONSE],
+      ["worker not available service not found", QueueErrorType.SERVICE_BINDING_NOT_FOUND],
+      ["pdf worker not available", QueueErrorType.SERVICE_BINDING_NOT_FOUND],
+      ["R2 binding not available", QueueErrorType.SERVICE_BINDING_NOT_FOUND],
+      ["object not found 404", QueueErrorType.FILE_NOT_FOUND],
+      ["failed to fetch pdf from r2", QueueErrorType.FILE_NOT_FOUND],
+      ["r2 object does not exist no such key", QueueErrorType.FILE_NOT_FOUND],
+      ["schema validation zod error", QueueErrorType.PARSE_VALIDATION_ERROR],
+      ["required field missing type mismatch", QueueErrorType.PARSE_VALIDATION_ERROR],
+    ])("classifies %s", (message, expectedType) => {
+      const error = classifyQueueError(new Error(message));
+
+      expect(error.type).toBe(expectedType);
+      expect(error.isRetryable()).toBe(
+        [
+          QueueErrorType.DB_CONNECTION_ERROR,
+          QueueErrorType.SERVICE_BINDING_TIMEOUT,
+          QueueErrorType.R2_THROTTLE,
+          QueueErrorType.AI_PROVIDER_ERROR,
+        ].includes(expectedType),
+      );
+    });
+
+    it("extracts messages from strings, causes, response-like objects, and unknown values", () => {
+      expect(classifyQueueError("api request failed").type).toBe(QueueErrorType.AI_PROVIDER_ERROR);
+      expect(classifyQueueError(new Error("outer", { cause: new Error("invalid pdf") })).type).toBe(
+        QueueErrorType.INVALID_PDF,
+      );
+      expect(classifyQueueError({ message: "binding not available" }).type).toBe(
+        QueueErrorType.SERVICE_BINDING_NOT_FOUND,
+      );
+      expect(classifyQueueError({ error: "validation error" }).type).toBe(
+        QueueErrorType.PARSE_VALIDATION_ERROR,
+      );
+      expect(classifyQueueError({ status: 429 }).type).toBe(QueueErrorType.R2_THROTTLE);
+      expect(classifyQueueError(null).type).toBe(QueueErrorType.UNKNOWN);
+    });
+
+    it("serializes non-Error original errors and checks retryability for unknown values", () => {
+      const original = { error: "validation error" };
+      const queueError = new QueueError(
+        QueueErrorType.PARSE_VALIDATION_ERROR,
+        "schema validation",
+        original,
+      );
+
+      expect(queueError.toJSON().originalError).toBe(original);
+      expect(isRetryableError("timeout")).toBe(true);
+      expect(isRetryableError({ error: "invalid pdf" })).toBe(false);
+    });
+
+    it("handles missing V8 stack helpers and malformed response-like objects", () => {
+      const errorConstructor = Error as unknown as {
+        captureStackTrace?: typeof Error.captureStackTrace | undefined;
+      };
+      const originalCaptureStackTrace = errorConstructor.captureStackTrace;
+      errorConstructor.captureStackTrace = undefined;
+
+      try {
+        const queueError = new QueueError(QueueErrorType.UNKNOWN, "no stack helper");
+        expect(queueError.name).toBe("QueueError");
+      } finally {
+        errorConstructor.captureStackTrace = originalCaptureStackTrace;
+      }
+
+      expect(classifyQueueError({ message: 123, error: 456, status: "429" }).type).toBe(
+        QueueErrorType.UNKNOWN,
+      );
     });
 
     it("should allow proper JSON serialization for DLQ/retry consumers", () => {

--- a/__tests__/unit/lib/resume-status-do.test.ts
+++ b/__tests__/unit/lib/resume-status-do.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runtime = vi.hoisted(() => ({
+  nextClient: null as FakeSocket | null,
+  nextServer: null as FakeSocket | null,
+}));
+
+class FakeSocket {
+  sent: string[] = [];
+  closed: Array<{ code: number; reason: string }> = [];
+
+  send(payload: string) {
+    this.sent.push(payload);
+  }
+
+  close(code: number, reason: string) {
+    this.closed.push({ code, reason });
+  }
+}
+
+class ThrowingSocket extends FakeSocket {
+  override send() {
+    throw new Error("closed");
+  }
+
+  override close() {
+    throw new Error("already closed");
+  }
+}
+
+vi.mock("cloudflare:workers", () => ({
+  DurableObject: class {
+    ctx: unknown;
+    env: unknown;
+
+    constructor(ctx: unknown, env: unknown) {
+      this.ctx = ctx;
+      this.env = env;
+    }
+  },
+}));
+
+function installWebSocketPair(client = new FakeSocket(), server = new FakeSocket()) {
+  runtime.nextClient = client;
+  runtime.nextServer = server;
+  vi.stubGlobal(
+    "WebSocketPair",
+    class {
+      0 = runtime.nextClient;
+      1 = runtime.nextServer;
+    },
+  );
+  return { client, server };
+}
+
+function createObject() {
+  const values = new Map<string, string>();
+  const sockets: FakeSocket[] = [];
+  const ctx = {
+    storage: {
+      get: vi.fn(async (keys: string[]) => {
+        const result = new Map<string, string>();
+        for (const key of keys) {
+          if (values.has(key)) {
+            result.set(key, values.get(key) ?? "");
+          }
+        }
+        return result;
+      }),
+      put: vi.fn(async (items: Record<string, string>) => {
+        for (const [key, value] of Object.entries(items)) {
+          values.set(key, value);
+        }
+      }),
+      setAlarm: vi.fn(async () => undefined),
+      deleteAll: vi.fn(async () => values.clear()),
+    },
+    acceptWebSocket: vi.fn((socket: FakeSocket) => {
+      sockets.push(socket);
+    }),
+    getWebSockets: vi.fn(() => sockets),
+    sockets,
+    values,
+  };
+
+  return import("@/lib/durable-objects/resume-status").then(({ ClickfolioStatusDO }) => ({
+    instance: new ClickfolioStatusDO(ctx as never, {} as never) as InstanceType<
+      typeof ClickfolioStatusDO
+    >,
+    ctx,
+  }));
+}
+
+describe("ClickfolioStatusDO", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects non-upgrade requests, unauthenticated sockets, and malformed notify bodies", async () => {
+    const { instance } = await createObject();
+
+    await expect(instance.fetch(new Request("https://do.example/"))).resolves.toMatchObject({
+      status: 404,
+    });
+    await expect(
+      instance.fetch(new Request("https://do.example/", { headers: { Upgrade: "websocket" } })),
+    ).resolves.toMatchObject({ status: 401 });
+    await expect(
+      instance.fetch(new Request("https://do.example/notify", { method: "POST", body: "{" })),
+    ).resolves.toMatchObject({ status: 400 });
+    await expect(
+      instance.fetch(
+        new Request("https://do.example/notify", {
+          method: "POST",
+          body: JSON.stringify({ error: "missing" }),
+        }),
+      ),
+    ).resolves.toMatchObject({ status: 400 });
+  });
+
+  it("accepts authenticated websocket upgrades and sends cached status immediately", async () => {
+    const { client, server } = installWebSocketPair();
+    const { ctx, instance } = await createObject();
+    ctx.values.set("lastStatus", "failed");
+    ctx.values.set("lastError", "Parse failed");
+
+    await expect(
+      instance.fetch(
+        new Request("https://do.example/", {
+          headers: {
+            Upgrade: "websocket",
+            "X-Authenticated-User-Id": "user_1",
+          },
+        }),
+      ),
+    ).rejects.toThrow(/status/);
+
+    expect(ctx.acceptWebSocket).toHaveBeenCalledWith(server);
+    expect(JSON.parse(server.sent[0])).toMatchObject({
+      type: "status",
+      status: "failed",
+      error: "Parse failed",
+    });
+    expect(client).toBeInstanceOf(FakeSocket);
+  });
+
+  it("stores status updates, broadcasts them, and schedules terminal cleanup", async () => {
+    const { server } = installWebSocketPair();
+    const { ctx, instance } = await createObject();
+    await expect(
+      instance.fetch(
+        new Request("https://do.example/", {
+          headers: {
+            Upgrade: "websocket",
+            "X-Authenticated-User-Id": "user_1",
+          },
+        }),
+      ),
+    ).rejects.toThrow(/status/);
+    ctx.sockets.push(new ThrowingSocket());
+
+    const response = await instance.fetch(
+      new Request("https://do.example/notify", {
+        method: "POST",
+        body: JSON.stringify({ status: "completed", error: "ignored by clients" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(ctx.values.get("lastStatus")).toBe("completed");
+    expect(ctx.values.get("lastError")).toBe("ignored by clients");
+    expect(JSON.parse(server.sent.at(-1) ?? "{}")).toMatchObject({
+      type: "status",
+      status: "completed",
+      error: "ignored by clients",
+    });
+    expect(ctx.storage.setAlarm).toHaveBeenCalledWith(expect.any(Number));
+  });
+
+  it("responds to websocket pings, status requests, errors, and cleanup alarms", async () => {
+    const { ctx, instance } = await createObject();
+    const socket = new FakeSocket();
+    const closedSocket = new ThrowingSocket();
+    ctx.sockets.push(socket, closedSocket);
+    ctx.values.set("lastStatus", "processing");
+    ctx.values.set("lastError", "");
+
+    await instance.webSocketMessage(socket as never, new ArrayBuffer(1));
+    await instance.webSocketMessage(socket as never, "ping");
+    await instance.webSocketMessage(socket as never, "status");
+    await instance.webSocketClose(socket as never, 1000, "done", true);
+    await instance.webSocketError(socket as never, new Error("boom"));
+    await instance.alarm();
+
+    expect(socket.sent[0]).toBe("pong");
+    expect(JSON.parse(socket.sent[1])).toMatchObject({
+      type: "status",
+      status: "processing",
+    });
+    expect(socket.closed).toContainEqual({ code: 1011, reason: "WebSocket error" });
+    expect(socket.closed).toContainEqual({ code: 1000, reason: "Resume processing complete" });
+    expect(ctx.storage.deleteAll).toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/lib/resume-status-do.test.ts
+++ b/__tests__/unit/lib/resume-status-do.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const runtime = vi.hoisted(() => ({
   nextClient: null as FakeSocket | null,
@@ -96,6 +96,10 @@ describe("ClickfolioStatusDO", () => {
     vi.restoreAllMocks();
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("rejects non-upgrade requests, unauthenticated sockets, and malformed notify bodies", async () => {
     const { instance } = await createObject();
 
@@ -189,7 +193,12 @@ describe("ClickfolioStatusDO", () => {
     await instance.webSocketMessage(socket as never, "ping");
     await instance.webSocketMessage(socket as never, "status");
     await instance.webSocketClose(socket as never, 1000, "done", true);
-    await instance.webSocketError(socket as never, new Error("boom"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await instance.webSocketError(socket as never, new Error("boom"));
+    } finally {
+      errorSpy.mockRestore();
+    }
     await instance.alarm();
 
     expect(socket.sent[0]).toBe("pong");

--- a/__tests__/unit/lib/seo-json-ld.test.ts
+++ b/__tests__/unit/lib/seo-json-ld.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+import {
+  generateBreadcrumbJsonLd,
+  generateExploreJsonLd,
+  generateFAQJsonLd,
+  generateHomepageJsonLd,
+  generatePageBreadcrumbJsonLd,
+  generateResumeJsonLd,
+  generateWebPageJsonLd,
+  serializeJsonLd,
+} from "@/lib/seo/json-ld";
+import type { ResumeContent } from "@/lib/types/database";
+
+const fullContent: ResumeContent = {
+  full_name: "Avery Quinn",
+  headline: "Staff Product Engineer",
+  summary: "Builds reliable product systems.",
+  contact: {
+    email: "avery@example.com",
+    linkedin: " https://linkedin.com/in/avery-quinn ",
+    github: "https://github.com/averyquinn",
+    website: "https://avery.dev/work",
+    dribbble: "https://dribbble.com/avery",
+    behance: "https://behance.net/avery",
+  },
+  experience: [
+    {
+      title: "Staff Engineer",
+      company: "Acme",
+      location: "Remote",
+      start_date: "2023-01",
+      description: "Current role",
+      highlights: [],
+    },
+    {
+      title: "Lead Engineer",
+      company: "Beta",
+      location: "Phoenix",
+      start_date: "2020-01",
+      end_date: "2022-12",
+      description: "Previous role",
+      highlights: [],
+    },
+  ],
+  education: [
+    {
+      degree: "BS Computer Science",
+      institution: "State University",
+      graduation_date: "2018",
+    },
+  ],
+  skills: [
+    { category: "Frontend", items: ["React", "TypeScript", "React", ""] },
+    { category: "Platform", items: ["Cloudflare"] },
+  ],
+  certifications: [],
+  projects: [],
+};
+
+describe("JSON-LD generators", () => {
+  it("builds a rich public ProfilePage schema from resume content", () => {
+    const jsonLd = generateResumeJsonLd(fullContent, {
+      profileUrl: "https://clickfolio.me/@avery",
+      avatarUrl: "https://cdn.example.com/avatar.png",
+      dateCreated: "2026-01-02",
+      dateModified: "2026-01-03",
+      includeEmail: true,
+    });
+
+    expect(jsonLd).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "ProfilePage",
+      "@id": "https://clickfolio.me/@avery#webpage",
+      dateCreated: "2026-01-02",
+      dateModified: "2026-01-03",
+      mainEntity: {
+        "@type": "Person",
+        name: "Avery Quinn",
+        url: "https://clickfolio.me/@avery",
+        image: "https://cdn.example.com/avatar.png",
+        jobTitle: "Staff Engineer",
+        worksFor: { "@type": "Organization", name: "Acme" },
+        email: "avery@example.com",
+        description: "Builds reliable product systems.",
+      },
+    });
+    expect(jsonLd.mainEntity.sameAs).toEqual([
+      "https://linkedin.com/in/avery-quinn",
+      "https://github.com/averyquinn",
+      "https://avery.dev/work",
+      "https://dribbble.com/avery",
+      "https://behance.net/avery",
+    ]);
+    expect(jsonLd.mainEntity.knowsAbout).toEqual(["React", "TypeScript", "Cloudflare"]);
+    expect(jsonLd.mainEntity.alumniOf).toEqual([
+      { "@type": "EducationalOrganization", name: "State University" },
+    ]);
+    expect(jsonLd.mainEntity.hasOccupation).toHaveLength(2);
+    expect(jsonLd.mainEntity.hasOccupation?.[0]).not.toHaveProperty("endDate");
+    expect(jsonLd.mainEntity.hasOccupation?.[1]).toMatchObject({ endDate: "2022-12" });
+  });
+
+  it("omits optional person fields when resume data is empty or invalid", () => {
+    const jsonLd = generateResumeJsonLd(
+      {
+        ...fullContent,
+        summary: "   ",
+        contact: {
+          email: "avery@example.com",
+          linkedin: "https://linkedin.com/feed",
+          github: "https://github.com/org/repo",
+          website: "javascript:alert(1)",
+          dribbble: "https://example.com/avery",
+          behance: "https://behance.net/",
+        },
+        experience: [],
+        education: [{ degree: "BS", institution: "   ", graduation_date: "2018" }],
+        skills: [{ category: "Empty", items: ["", "   "] }],
+      },
+      {
+        profileUrl: "https://clickfolio.me/@avery",
+      },
+    );
+
+    expect(jsonLd.mainEntity).not.toHaveProperty("image");
+    expect(jsonLd.mainEntity).not.toHaveProperty("worksFor");
+    expect(jsonLd.mainEntity).not.toHaveProperty("hasOccupation");
+    expect(jsonLd.mainEntity).not.toHaveProperty("alumniOf");
+    expect(jsonLd.mainEntity).not.toHaveProperty("sameAs");
+    expect(jsonLd.mainEntity).not.toHaveProperty("knowsAbout");
+    expect(jsonLd.mainEntity).not.toHaveProperty("email");
+    expect(jsonLd.mainEntity).not.toHaveProperty("description");
+  });
+
+  it("escapes JSON-LD script-breakout characters during serialization", () => {
+    const serialized = serializeJsonLd({
+      text: "</script><script>alert(1)</script>",
+      separator: "\u2028",
+      paragraph: "\u2029",
+    });
+
+    expect(serialized).toContain("\\u003c/script\\u003e");
+    expect(serialized).toContain("\\u003cscript\\u003e");
+    expect(serialized).toContain("\\u2028");
+    expect(serialized).toContain("\\u2029");
+  });
+
+  it("builds site-level JSON-LD structures for public pages", () => {
+    const homepage = generateHomepageJsonLd();
+    expect(homepage.map((entry) => entry["@type"])).toEqual([
+      "WebSite",
+      "Organization",
+      "SoftwareApplication",
+    ]);
+
+    expect(
+      generateExploreJsonLd([{ handle: "avery", name: "Avery", headline: "Engineer" }]),
+    ).toMatchObject({
+      "@type": "CollectionPage",
+      mainEntity: {
+        numberOfItems: 1,
+        itemListElement: [
+          {
+            position: 1,
+            url: "https://clickfolio.me/@avery",
+            name: "Avery",
+            description: "Engineer",
+          },
+        ],
+      },
+    });
+
+    expect(generateFAQJsonLd()).toMatchObject({
+      "@type": "FAQPage",
+      mainEntity: expect.arrayContaining([
+        expect.objectContaining({
+          "@type": "Question",
+          acceptedAnswer: expect.objectContaining({ "@type": "Answer" }),
+        }),
+      ]),
+    });
+
+    expect(generatePageBreadcrumbJsonLd("Terms", "/terms")).toMatchObject({
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        expect.objectContaining({ position: 1, name: "Home" }),
+        expect.objectContaining({
+          position: 2,
+          name: "Terms",
+          item: "https://clickfolio.me/terms",
+        }),
+      ],
+    });
+
+    expect(
+      generateWebPageJsonLd("Privacy", "/privacy", "Privacy policy", "2026-01-01"),
+    ).toMatchObject({
+      "@type": "WebPage",
+      "@id": "https://clickfolio.me/privacy#webpage",
+      dateModified: "2026-01-01",
+    });
+
+    expect(generateBreadcrumbJsonLd("avery", "Avery Quinn")).toMatchObject({
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        expect.objectContaining({ name: "Home" }),
+        expect.objectContaining({ name: "Explore" }),
+        expect.objectContaining({ name: "Avery Quinn", item: "https://clickfolio.me/@avery" }),
+      ],
+    });
+  });
+});

--- a/__tests__/unit/lib/umami-client.test.ts
+++ b/__tests__/unit/lib/umami-client.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const env = {
+  UMAMI_API_URL: "https://umami.example",
+  UMAMI_USERNAME: "avery",
+  UMAMI_PASSWORD: "secret",
+} as CloudflareEnv;
+
+async function loadClient() {
+  vi.resetModules();
+  process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID = "site_123";
+  return import("@/lib/umami/client");
+}
+
+describe("Umami analytics client", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    delete (process.env as Record<string, string | undefined>).NEXT_PUBLIC_UMAMI_WEBSITE_ID;
+  });
+
+  it("authenticates once and sends filtered stats, pageview, and metric requests", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/api/auth/login")) {
+        expect(init?.method).toBe("POST");
+        expect(JSON.parse(String(init?.body))).toEqual({
+          username: "avery",
+          password: "secret",
+        });
+        return Response.json({ token: "token-1" });
+      }
+      if (url.includes("/stats?")) {
+        return Response.json({
+          pageviews: 12,
+          visitors: 4,
+          visits: 5,
+          bounces: 1,
+          totaltime: 60,
+          comparison: {
+            pageviews: 1,
+            visitors: 2,
+            visits: 3,
+            bounces: 4,
+            totaltime: 5,
+          },
+        });
+      }
+      if (url.includes("/pageviews?")) {
+        return Response.json({
+          pageviews: [{ x: "2026-05-20", y: 8 }],
+          sessions: [{ x: "2026-05-20", y: 3 }],
+        });
+      }
+      return Response.json([{ x: "linkedin.com", y: 2 }]);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getMetrics, getPageviews, getStats } = await loadClient();
+
+    await expect(getStats(env, { startAt: 1, endAt: 2, path: "/@avery" })).resolves.toMatchObject({
+      pageviews: 12,
+      visitors: 4,
+    });
+    await expect(
+      getPageviews(env, {
+        startAt: 3,
+        endAt: 4,
+        unit: "day",
+        timezone: "America/Phoenix",
+        path: "/@avery",
+      }),
+    ).resolves.toMatchObject({ pageviews: [{ x: "2026-05-20", y: 8 }] });
+    await expect(
+      getMetrics(env, {
+        startAt: 5,
+        endAt: 6,
+        type: "referrer",
+        unit: "day",
+        timezone: "America/Phoenix",
+        path: "/@avery",
+        limit: 5,
+      }),
+    ).resolves.toEqual([{ x: "linkedin.com", y: 2 }]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(String(fetchMock.mock.calls[1][0])).toBe(
+      "https://umami.example/api/websites/site_123/stats?startAt=1&endAt=2&path=%2F%40avery",
+    );
+    expect(String(fetchMock.mock.calls[2][0])).toContain("unit=day");
+    expect(String(fetchMock.mock.calls[2][0])).toContain("timezone=America%2FPhoenix");
+    expect(String(fetchMock.mock.calls[3][0])).toContain("limit=5");
+    expect(fetchMock.mock.calls[1][1]?.headers).toEqual({ Authorization: "Bearer token-1" });
+  });
+
+  it("clears the cached token and retries once after an API 401", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ token: "expired" }))
+      .mockResolvedValueOnce(
+        new Response("unauthorized", { status: 401, statusText: "Unauthorized" }),
+      )
+      .mockResolvedValueOnce(Response.json({ token: "fresh" }))
+      .mockResolvedValueOnce(Response.json([{ x: "US", y: 7 }]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getMetrics } = await loadClient();
+
+    await expect(
+      getMetrics(env, {
+        startAt: 1,
+        endAt: 2,
+        type: "country",
+        unit: "day",
+        timezone: "UTC",
+      }),
+    ).resolves.toEqual([{ x: "US", y: 7 }]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock.mock.calls[1][1]?.headers).toEqual({ Authorization: "Bearer expired" });
+    expect(fetchMock.mock.calls[3][1]?.headers).toEqual({ Authorization: "Bearer fresh" });
+  });
+
+  it("throws clear errors for failed authentication and non-auth API failures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { status: 403, statusText: "Forbidden" })),
+    );
+    const authClient = await loadClient();
+
+    await expect(authClient.getUmamiToken(env)).rejects.toThrow("Umami auth failed: 403 Forbidden");
+
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(Response.json({ token: "token" }))
+        .mockResolvedValueOnce(new Response("boom", { status: 502, statusText: "Bad Gateway" })),
+    );
+    const apiClient = await loadClient();
+
+    await expect(apiClient.getStats(env, { startAt: 1, endAt: 2 })).rejects.toThrow(
+      "Umami API error: 502 Bad Gateway",
+    );
+  });
+});

--- a/__tests__/unit/lib/utils-coverage.test.ts
+++ b/__tests__/unit/lib/utils-coverage.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 import type { ResumeContent } from "@/lib/types/database";
 import { copyToClipboard } from "@/lib/utils/clipboard";
 import { isLocalEnvironment } from "@/lib/utils/environment";
@@ -157,7 +157,11 @@ describe("upload validation utilities", () => {
 describe("clipboard utilities", () => {
   const originalClipboard = navigator.clipboard;
   const originalExecCommand = document.execCommand;
-  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  let consoleError: MockInstance;
+
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
 
   afterEach(() => {
     Object.defineProperty(navigator, "clipboard", {
@@ -165,7 +169,7 @@ describe("clipboard utilities", () => {
       configurable: true,
     });
     document.execCommand = originalExecCommand;
-    consoleError.mockClear();
+    consoleError.mockRestore();
   });
 
   it("uses the Clipboard API when available", async () => {

--- a/__tests__/unit/lib/utils-coverage.test.ts
+++ b/__tests__/unit/lib/utils-coverage.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResumeContent } from "@/lib/types/database";
+import { copyToClipboard } from "@/lib/utils/clipboard";
+import { isLocalEnvironment } from "@/lib/utils/environment";
+import { classifyError, getErrorMessage, showErrorToast } from "@/lib/utils/errors";
+import { formatRelativeTime, truncateText } from "@/lib/utils/format";
+import { calculateCompleteness, getProfileSuggestions } from "@/lib/utils/profile-completeness";
+import { generateReferralCode } from "@/lib/utils/referral-code";
+import {
+  generateTempKey,
+  validatePDF,
+  validatePDFBuffer,
+  validateRequestSize,
+} from "@/lib/utils/validation";
+
+const toastError = vi.fn();
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+const completeResume: ResumeContent = {
+  full_name: "Avery Quinn",
+  headline: "Engineer",
+  summary: "Builds products",
+  contact: {
+    email: "avery@example.com",
+    linkedin: "https://linkedin.com/in/avery",
+  },
+  experience: [
+    {
+      title: "Engineer",
+      company: "Acme",
+      start_date: "2024-01",
+      description: "Work",
+      highlights: [],
+    },
+    {
+      title: "Developer",
+      company: "Beta",
+      start_date: "2022-01",
+      description: "Work",
+      highlights: [],
+    },
+  ],
+  education: [{ degree: "BS", institution: "State", graduation_date: "2020" }],
+  skills: [{ category: "Languages", items: ["TypeScript"] }],
+  certifications: [{ name: "Cert", issuer: "Org", date: "2024" }],
+  projects: [],
+};
+
+describe("profile completeness utilities", () => {
+  it("scores complete and sparse resumes and returns targeted suggestions", () => {
+    expect(calculateCompleteness(completeResume)).toBe(100);
+    expect(getProfileSuggestions(completeResume)).toEqual([]);
+
+    const sparseResume: ResumeContent = {
+      ...completeResume,
+      full_name: "",
+      headline: "",
+      summary: "",
+      contact: { email: "" },
+      experience: [],
+      education: [],
+      skills: [],
+      certifications: [],
+    };
+
+    expect(calculateCompleteness(sparseResume)).toBe(0);
+    expect(getProfileSuggestions(sparseResume)).toEqual([
+      "Add your education background",
+      "List your technical skills",
+      "Add certifications to stand out",
+      "Add more work experience entries",
+      "Link your professional social profiles",
+    ]);
+  });
+});
+
+describe("formatting utilities", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-20T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("formats relative time across minute, hour, day, and date ranges", () => {
+    expect(formatRelativeTime("2026-05-20T12:00:00Z")).toBe("Just now");
+    expect(formatRelativeTime("2026-05-20T11:58:00Z")).toBe("2 minutes ago");
+    expect(formatRelativeTime("2026-05-20T10:00:00Z")).toBe("2 hours ago");
+    expect(formatRelativeTime("2026-05-18T12:00:00Z")).toBe("2 days ago");
+    expect(formatRelativeTime("2026-02-01T12:00:00Z")).toBe("Feb 1, 2026");
+  });
+
+  it("truncates only when text exceeds the requested length", () => {
+    expect(truncateText("short", 10)).toBe("short");
+    expect(truncateText("a long sentence", 8)).toBe("a long s...");
+  });
+});
+
+describe("upload validation utilities", () => {
+  it("validates PDF files, filenames, buffers, and request sizes", () => {
+    expect(validatePDF(new File(["x"], "resume.pdf", { type: "application/pdf" }))).toEqual({
+      valid: true,
+    });
+    expect(validatePDF(new File(["x"], "resume.txt", { type: "text/plain" }))).toEqual({
+      valid: false,
+      error: "Only PDF files are allowed",
+    });
+    expect(
+      validatePDF(new File([new Uint8Array(6_000_000)], "large.pdf", { type: "application/pdf" })),
+    ).toEqual({
+      valid: false,
+      error: "File size must be less than 5MB",
+    });
+
+    expect(validatePDFBuffer(new Uint8Array([0x25, 0x50, 0x44, 0x46]).buffer)).toEqual({
+      valid: true,
+    });
+    expect(validatePDFBuffer(new Uint8Array([0x00, 0x50, 0x44, 0x46]).buffer)).toEqual({
+      valid: false,
+      error: "File is not a valid PDF (invalid magic number)",
+    });
+
+    const cleanKey = generateTempKey("../my resume!.txt");
+    expect(cleanKey).toMatch(/^temp\/00000000-0000-0000-0000-000000000001\/my_resume_\.txt\.pdf$/);
+
+    expect(validateRequestSize(new Request("https://example.com"))).toEqual({ valid: true });
+    expect(
+      validateRequestSize(
+        new Request("https://example.com", { headers: { "content-length": "not-a-number" } }),
+      ),
+    ).toEqual({ valid: false, error: "Invalid content-length header" });
+    expect(
+      validateRequestSize(
+        new Request("https://example.com", { headers: { "content-length": "6" } }),
+        5,
+      ),
+    ).toEqual({
+      valid: false,
+      error: "Request body too large (0.0MB). Maximum size is 0.0MB.",
+    });
+    expect(
+      validateRequestSize(
+        new Request("https://example.com", { headers: { "content-length": "5" } }),
+        5,
+      ),
+    ).toEqual({ valid: true });
+  });
+});
+
+describe("clipboard utilities", () => {
+  const originalClipboard = navigator.clipboard;
+  const originalExecCommand = document.execCommand;
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  afterEach(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: originalClipboard,
+      configurable: true,
+    });
+    document.execCommand = originalExecCommand;
+    consoleError.mockClear();
+  });
+
+  it("uses the Clipboard API when available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    await expect(copyToClipboard("hello")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it("falls back to execCommand and reports failures", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+    });
+    document.execCommand = vi.fn().mockReturnValue(true);
+
+    await expect(copyToClipboard("fallback")).resolves.toBe(true);
+    expect(document.execCommand).toHaveBeenCalledWith("copy");
+
+    document.execCommand = vi.fn(() => {
+      throw new Error("blocked");
+    });
+    await expect(copyToClipboard("blocked")).resolves.toBe(false);
+    expect(consoleError).toHaveBeenCalled();
+  });
+});
+
+describe("error and environment utilities", () => {
+  const originalHref = window.location.href;
+  const originalAuthUrl = process.env.BETTER_AUTH_URL;
+
+  afterEach(() => {
+    toastError.mockClear();
+    process.env.BETTER_AUTH_URL = originalAuthUrl;
+    window.history.replaceState({}, "", originalHref);
+  });
+
+  it("classifies status codes and returns user-facing messages", () => {
+    expect(classifyError(401)).toBe("auth");
+    expect(classifyError(403)).toBe("auth");
+    expect(classifyError(404)).toBe("fatal");
+    expect(classifyError(422)).toBe("validation");
+    expect(classifyError(400)).toBe("validation");
+    expect(classifyError(429)).toBe("rate_limit");
+    expect(classifyError(503)).toBe("transient");
+    expect(classifyError(0)).toBe("transient");
+    expect(classifyError(418)).toBe("fatal");
+
+    expect(getErrorMessage(413)).toBe("File too large. Maximum size is 5MB.");
+    expect(getErrorMessage(499, "upload")).toBe("Something went wrong with upload.");
+  });
+
+  it("shows category-specific toasts and detects local app URLs", () => {
+    showErrorToast(401);
+    const authToastOptions = toastError.mock.calls[0]?.[1] as { action?: { onClick: () => void } };
+    authToastOptions.action?.onClick();
+    expect(window.location.href).toBe("http://localhost:3000/");
+
+    showErrorToast(429);
+    expect(toastError).toHaveBeenCalledWith(expect.any(String), { duration: 10000 });
+
+    showErrorToast(500, "profile");
+    expect(toastError).toHaveBeenCalledWith("Server error. We're working on it.");
+
+    process.env.BETTER_AUTH_URL = "http://127.0.0.1:3000";
+    expect(isLocalEnvironment()).toBe(true);
+    process.env.BETTER_AUTH_URL = "https://clickfolio.me";
+    expect(isLocalEnvironment()).toBe(false);
+  });
+});
+
+describe("referral code generation", () => {
+  it("generates alphabet-safe codes and falls back if Web Crypto fails", () => {
+    const code = generateReferralCode();
+    expect(code).toMatch(/^[A-HJ-NP-Z2-9]{8}$/);
+
+    const getRandomValues = vi.spyOn(crypto, "getRandomValues").mockImplementation(() => {
+      throw new Error("no crypto");
+    });
+    const mathRandom = vi.spyOn(Math, "random").mockReturnValue(0.123456);
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(1_779_248_853_000);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(generateReferralCode()).toHaveLength(8);
+
+    getRandomValues.mockRestore();
+    mathRandom.mockRestore();
+    dateNow.mockRestore();
+    consoleError.mockRestore();
+  });
+});

--- a/__tests__/unit/lib/wait-for-completion.test.ts
+++ b/__tests__/unit/lib/wait-for-completion.test.ts
@@ -21,6 +21,8 @@ class MockWebSocket {
 }
 
 describe("waitForResumeCompletion", () => {
+  const originalLocation = window.location;
+
   beforeEach(() => {
     vi.useFakeTimers();
     MockWebSocket.instances = [];
@@ -34,6 +36,10 @@ describe("waitForResumeCompletion", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      configurable: true,
+    });
   });
 
   it("resolves from a terminal WebSocket status and cleans up keepalive timers", async () => {

--- a/__tests__/unit/lib/wait-for-completion.test.ts
+++ b/__tests__/unit/lib/wait-for-completion.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { waitForResumeCompletion } from "@/lib/utils/wait-for-completion";
+
+class MockWebSocket {
+  static OPEN = 1;
+  static instances: MockWebSocket[] = [];
+
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onclose: ((event: { code: number }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  readyState = MockWebSocket.OPEN;
+  send = vi.fn();
+  close = vi.fn();
+  url: string;
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+}
+
+describe("waitForResumeCompletion", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    Object.defineProperty(window, "location", {
+      value: { protocol: "https:", host: "clickfolio.test" },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves from a terminal WebSocket status and cleans up keepalive timers", async () => {
+    const resultPromise = waitForResumeCompletion("res_123", 60_000);
+    const ws = MockWebSocket.instances[0];
+
+    expect(ws.url).toBe("wss://clickfolio.test/ws/resume-status?resume_id=res_123");
+    ws.onopen?.();
+    await vi.advanceTimersByTimeAsync(30_001);
+    expect(ws.send).toHaveBeenCalledWith("ping");
+
+    ws.onmessage?.({ data: "pong" });
+    ws.onmessage?.({ data: "{bad json" });
+    ws.onmessage?.({ data: JSON.stringify({ type: "ignored", status: "completed" }) });
+    ws.onmessage?.({ data: JSON.stringify({ type: "status", status: "completed" }) });
+
+    await expect(resultPromise).resolves.toEqual({ status: "completed" });
+    expect(ws.close).toHaveBeenCalledWith(1000, "done");
+  });
+
+  it("falls back to polling after repeated WebSocket closes", async () => {
+    let pollCount = 0;
+    globalThis.fetch = vi.fn(async () => {
+      pollCount += 1;
+      return Response.json(
+        pollCount === 1 ? { status: "processing" } : { status: "failed", error: "Parser failed" },
+      );
+    }) as unknown as typeof fetch;
+
+    const resultPromise = waitForResumeCompletion("res_retry", 20_000);
+    MockWebSocket.instances[0].onclose?.({ code: 1006 });
+    await vi.advanceTimersByTimeAsync(1000);
+    MockWebSocket.instances[1].onerror?.();
+    MockWebSocket.instances[1].onclose?.({ code: 1006 });
+    await vi.advanceTimersByTimeAsync(2000);
+    MockWebSocket.instances[2].onclose?.({ code: 1006 });
+
+    await vi.advanceTimersByTimeAsync(3000);
+    await expect(resultPromise).resolves.toEqual({ status: "failed", error: "Parser failed" });
+    expect(fetch).toHaveBeenCalledWith("/api/resume/status?resume_id=res_retry");
+  });
+
+  it("times out when no terminal status arrives", async () => {
+    const resultPromise = waitForResumeCompletion("res_timeout", 50);
+    await vi.advanceTimersByTimeAsync(50);
+
+    await expect(resultPromise).resolves.toEqual({
+      status: "failed",
+      error: "Timed out waiting for resume processing",
+    });
+    expect(MockWebSocket.instances[0].close).toHaveBeenCalledWith(1000, "done");
+  });
+});

--- a/components/YouAreLiveModal.tsx
+++ b/components/YouAreLiveModal.tsx
@@ -185,7 +185,7 @@ export function YouAreLiveModal({ open, onOpenChange, handle, url }: YouAreLiveM
                 <Button
                   variant="secondary"
                   size="sm"
-                  aria-label="Copy referral link"
+                  aria-label={referralCopied ? "Referral link copied" : "Copy referral link"}
                   onClick={handleCopyReferralLink}
                   className="shrink-0"
                 >

--- a/components/YouAreLiveModal.tsx
+++ b/components/YouAreLiveModal.tsx
@@ -185,6 +185,7 @@ export function YouAreLiveModal({ open, onOpenChange, handle, url }: YouAreLiveM
                 <Button
                   variant="secondary"
                   size="sm"
+                  aria-label="Copy referral link"
                   onClick={handleCopyReferralLink}
                   className="shrink-0"
                 >

--- a/components/forms/HandleForm.tsx
+++ b/components/forms/HandleForm.tsx
@@ -105,7 +105,7 @@ export function HandleForm({ currentHandle, variant = "default" }: HandleFormPro
               type="button"
               variant="outline"
               size="icon"
-              aria-label="Copy public URL"
+              aria-label={copied ? "Public URL copied" : "Copy public URL"}
               onClick={handleCopy}
               className="shrink-0 h-[38px] w-[38px]"
             >
@@ -177,7 +177,7 @@ export function HandleForm({ currentHandle, variant = "default" }: HandleFormPro
               type="button"
               variant="outline"
               size="icon"
-              aria-label="Copy public URL"
+              aria-label={copied ? "Public URL copied" : "Copy public URL"}
               onClick={handleCopy}
               className="shrink-0"
             >

--- a/components/forms/HandleForm.tsx
+++ b/components/forms/HandleForm.tsx
@@ -105,6 +105,7 @@ export function HandleForm({ currentHandle, variant = "default" }: HandleFormPro
               type="button"
               variant="outline"
               size="icon"
+              aria-label="Copy public URL"
               onClick={handleCopy}
               className="shrink-0 h-[38px] w-[38px]"
             >
@@ -176,6 +177,7 @@ export function HandleForm({ currentHandle, variant = "default" }: HandleFormPro
               type="button"
               variant="outline"
               size="icon"
+              aria-label="Copy public URL"
               onClick={handleCopy}
               className="shrink-0"
             >

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,12 +26,11 @@ export default defineConfig({
         "lib/stubs/**",
         "lib/db/migrations/**",
       ],
-      // Coverage thresholds - set to current baseline to prevent regressions
       thresholds: {
-        statements: 30,
-        branches: 30,
-        functions: 25,
-        lines: 30,
+        statements: 80,
+        branches: 80,
+        functions: 80,
+        lines: 80,
       },
     },
   },


### PR DESCRIPTION
## Summary
- Raise Vitest coverage thresholds to 80% across statements, branches, functions, and lines.
- Add focused unit coverage for API routes, protected/public app pages, dashboard/settings/share flows, auth helpers, queue errors, Durable Object status handling, SEO JSON-LD, Umami, and utility branches.
- Add a CI `coverage-gate` job so PRs must pass `bun run test:coverage` before build and final success.

## Validation
- `bun run type-check`
- `bun run lint`
- `bun run test`
- `bun run test:coverage` -> statements 87.8%, branches 80.02%, functions 84.86%, lines 88.48%
- `bun run build`