### PR TITLE
feat(seo): strengthen rankings, brand entity, and AEO/GEO coverage

### DIFF
--- a/app/blog/best-resume-website-builders/page.tsx
+++ b/app/blog/best-resume-website-builders/page.tsx
@@ -32,28 +32,36 @@ export default function BestResumeWebsiteBuildersPage() {
     <BlogPostLayout post={post} relatedPosts={relatedPosts}>
       <section>
         <p>
-          The tool you choose to build your resume website matters. It affects how fast your site
-          loads, how it looks on mobile, whether recruiters can find you on Google, and how much
-          control you have over your data.
+          Most "best resume website builder" lists compare tools that do completely different jobs.
+          A resume builder that exports a PDF is not the same as a one-page site builder, and
+          neither is the same as a tool that turns your existing resume into a hosted portfolio. The
+          right pick depends on what you already have and what you want to end up with.
         </p>
         <p>
-          We tested 8 resume-to-website tools — ranking them on template quality, ease of use,
-          pricing, privacy, editing flexibility, and real web hosting. Here's what we found.
+          This guide compares seven tools that real people actually use in 2026, plus one that
+          recently shut down. For each one we cover what it is, what the free tier gives you,
+          whether you can use your own domain, and whether it can import a resume you already wrote.
+          We build{" "}
+          <Link href="/" className="text-brand font-semibold">
+            clickfolio.me
+          </Link>
+          , so treat us as a biased-but-honest source: we have noted where we fall short, including
+          the fact that we do not support custom domains yet.
         </p>
       </section>
 
       <section>
-        <h2>The Comparison at a Glance</h2>
+        <h2>The comparison at a glance</h2>
         <div className="overflow-x-auto my-8 not-prose">
           <table className="w-full border-collapse overflow-hidden rounded-lg border border-border text-sm">
             <thead>
               <tr className="bg-surface-2 text-foreground">
                 <th className="border border-border p-3 text-left font-semibold">Tool</th>
-                <th className="border border-border p-3 text-left font-semibold">Templates</th>
-                <th className="border border-border p-3 text-left font-semibold">Free Tier</th>
-                <th className="border border-border p-3 text-left font-semibold">Real Hosting</th>
+                <th className="border border-border p-3 text-left font-semibold">What it is</th>
+                <th className="border border-border p-3 text-left font-semibold">Free tier</th>
+                <th className="border border-border p-3 text-left font-semibold">Custom domain</th>
                 <th className="border border-border p-3 text-left font-semibold">
-                  Privacy Controls
+                  Imports your resume?
                 </th>
               </tr>
             </thead>
@@ -62,211 +70,218 @@ export default function BestResumeWebsiteBuildersPage() {
                 <td className="border border-border p-3 font-semibold text-foreground">
                   clickfolio.me
                 </td>
-                <td className="border border-border p-3">10</td>
+                <td className="border border-border p-3">AI resume-to-website</td>
                 <td className="border border-border p-3 text-brand font-semibold">Free forever</td>
-                <td className="border border-border p-3">Yes (Cloudflare)</td>
-                <td className="border border-border p-3">Granular field-level</td>
+                <td className="border border-border p-3">Not yet (clickfolio.me/@handle)</td>
+                <td className="border border-border p-3">Yes — PDF, parsed by AI</td>
               </tr>
               <tr>
                 <td className="border border-border p-3 font-semibold text-foreground">
-                  Magic Self
+                  Standard Resume
                 </td>
-                <td className="border border-border p-3">3</td>
-                <td className="border border-border p-3">Open source</td>
-                <td className="border border-border p-3">Self-hosted only</td>
-                <td className="border border-border p-3">None</td>
+                <td className="border border-border p-3">Resume builder + hosted web resume</td>
+                <td className="border border-border p-3">Free Basic</td>
+                <td className="border border-border p-3">Custom slug only (Pro $19/mo)</td>
+                <td className="border border-border p-3">LinkedIn import</td>
               </tr>
               <tr className="bg-card">
-                <td className="border border-border p-3 font-semibold text-foreground">DockPage</td>
-                <td className="border border-border p-3">5</td>
-                <td className="border border-border p-3">Limited</td>
-                <td className="border border-border p-3">Yes</td>
-                <td className="border border-border p-3">Basic</td>
+                <td className="border border-border p-3 font-semibold text-foreground">Carrd</td>
+                <td className="border border-border p-3">General one-page site builder</td>
+                <td className="border border-border p-3">3 sites on a subdomain</td>
+                <td className="border border-border p-3">Yes, Pro Standard $19/yr</td>
+                <td className="border border-border p-3">No — build by hand</td>
               </tr>
               <tr>
-                <td className="border border-border p-3 font-semibold text-foreground">
-                  SpaceLoom
-                </td>
-                <td className="border border-border p-3">4</td>
-                <td className="border border-border p-3">1 page free</td>
-                <td className="border border-border p-3">Subdomain</td>
-                <td className="border border-border p-3">None</td>
+                <td className="border border-border p-3 font-semibold text-foreground">Super.so</td>
+                <td className="border border-border p-3">Notion-to-website builder</td>
+                <td className="border border-border p-3">1 site on super.site</td>
+                <td className="border border-border p-3">Yes, from $16/mo</td>
+                <td className="border border-border p-3">No — content lives in Notion</td>
               </tr>
               <tr className="bg-card">
-                <td className="border border-border p-3 font-semibold text-foreground">
-                  EZfolio CV
-                </td>
-                <td className="border border-border p-3">6</td>
-                <td className="border border-border p-3">Free</td>
-                <td className="border border-border p-3">Subdomain</td>
-                <td className="border border-border p-3">None</td>
-              </tr>
-              <tr>
-                <td className="border border-border p-3 font-semibold text-foreground">Refolio</td>
-                <td className="border border-border p-3">8</td>
-                <td className="border border-border p-3">7-day trial</td>
-                <td className="border border-border p-3">Yes</td>
-                <td className="border border-border p-3">None</td>
-              </tr>
-              <tr className="bg-card">
-                <td className="border border-border p-3 font-semibold text-foreground">CVPage</td>
-                <td className="border border-border p-3">3</td>
-                <td className="border border-border p-3">Free</td>
-                <td className="border border-border p-3">Subdomain</td>
-                <td className="border border-border p-3">None</td>
-              </tr>
-              <tr>
                 <td className="border border-border p-3 font-semibold text-foreground">
                   Reactive Resume
                 </td>
-                <td className="border border-border p-3">2 (PDF only)</td>
-                <td className="border border-border p-3">Open source</td>
-                <td className="border border-border p-3">Self-hosted only</td>
-                <td className="border border-border p-3">None</td>
+                <td className="border border-border p-3">Open-source resume builder</td>
+                <td className="border border-border p-3">Free / self-hostable</td>
+                <td className="border border-border p-3">Only if self-hosted</td>
+                <td className="border border-border p-3">JSON / LinkedIn</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3 font-semibold text-foreground">
+                  JSON Resume
+                </td>
+                <td className="border border-border p-3">Open JSON standard + themes</td>
+                <td className="border border-border p-3">Free</td>
+                <td className="border border-border p-3">Depends on where you deploy</td>
+                <td className="border border-border p-3">JSON / CLI / gists</td>
+              </tr>
+              <tr className="bg-card">
+                <td className="border border-border p-3 font-semibold text-foreground">
+                  Kickresume
+                </td>
+                <td className="border border-border p-3">AI resume builder + website feature</td>
+                <td className="border border-border p-3">Free plan (Premium ~$8/mo)</td>
+                <td className="border border-border p-3">Not clearly documented</td>
+                <td className="border border-border p-3">AI-assisted entry</td>
               </tr>
             </tbody>
           </table>
         </div>
-      </section>
-
-      <section>
-        <h2>Detailed Reviews</h2>
-
-        <h3>clickfolio.me — Best Overall</h3>
         <p>
-          clickfolio.me takes the top spot for one simple reason: it's the only tool that combines
-          AI-powered PDF parsing, real web hosting, generous free tier, and granular privacy
-          controls in one package. Upload your existing PDF resume, and within 30 seconds you have a
-          live, hosted website at <code>@yourname</code>. Ten templates range from ATS-friendly
-          classics to bold creative designs, and you can switch between them instantly without
-          losing content. Built-in analytics show who's viewing your portfolio. Privacy controls let
-          you toggle individual fields on or off. And it's free forever — premium templates unlock
-          through referrals, not payment.
-        </p>
-
-        <h3>Magic Self — Best for Developers Who Want Full Control</h3>
-        <p>
-          Magic Self is an open-source project that generates a static portfolio site from your
-          resume data. It's well-built, and if you're comfortable with Git, npm, and deploying to
-          Vercel or Netlify, it works. But that's the catch — you need to be a developer. There's no
-          hosted version, no AI parsing, and only 3 basic templates. It's a good starting point for
-          a dev who wants to customize everything, but it's not a turnkey solution for most
-          professionals.
-        </p>
-
-        <h3>DockPage — Good LinkedIn Integration, Weak Free Tier</h3>
-        <p>
-          DockPage's strength is LinkedIn import — it pulls your profile data and builds a page from
-          it. This saves time if your LinkedIn is up to date. But the free tier is bare-bones:
-          limited customization, watermarks, and no analytics. Templates feel dated compared to
-          modern design standards. If you're willing to pay, the premium tier unlocks more, but for
-          most users, a free alternative with more features makes more sense.
-        </p>
-
-        <h3>SpaceLoom — Fast, but Inflexible</h3>
-        <p>
-          SpaceLoom generates a portfolio quickly from your resume, and the templates are clean and
-          modern. But once generated, editing is minimal — you can't add sections, rearrange
-          content, or switch designs. You get one free page on a subdomain. For a quick one-off
-          page, it works. For an ongoing professional presence you can update and control, it falls
-          short.
-        </p>
-
-        <h3>EZfolio CV — Decent Free Option, Limited Polish</h3>
-        <p>
-          EZfolio CV offers 6 templates and a free tier, which is generous. But the hosting is on a
-          subdomain (ezfolio.com/yourname), the templates lack polish, and there are no privacy
-          controls or analytics. It's a step above a PDF, but not by much.
-        </p>
-
-        <h3>Refolio — Beautiful Designs, No Free Tier</h3>
-        <p>
-          Refolio has some of the best-looking templates in this comparison — they're modern,
-          animated, and visually striking. But there's no free tier beyond a 7-day trial, and the
-          pricing is steep for what you get. If design is your absolute priority and you don't mind
-          paying, it's worth a look. For everyone else, free tools with comparable design quality
-          exist.
-        </p>
-
-        <h3>CVPage — Basic but Functional</h3>
-        <p>
-          CVPage is a simple, free tool with 3 templates. It gets the job done if you want something
-          basic. But it lacks AI parsing, so you're entering data manually. No privacy controls, no
-          analytics, and templates that look like they're from 2019. Fine for a first portfolio, but
-          you'll outgrow it quickly.
-        </p>
-
-        <h3>Reactive Resume — PDF Builder, Not a Portfolio Site</h3>
-        <p>
-          Reactive Resume is an excellent open-source resume builder — for PDFs. It creates
-          beautiful resume documents with a drag-and-drop editor. But it doesn't create websites. If
-          you need a PDF resume, it's one of the best tools out there. If you need a live portfolio
-          website, it's not what you're looking for.
+          Read.cv used to belong on this list. It was acquired by Perplexity in January 2025 and
+          wound down through the year, with data export ending May 16, 2025. It is no longer
+          available, so if you had a profile there, head to our{" "}
+          <Link href="/blog/read-cv-alternatives" className="text-brand font-semibold">
+            Read.cv alternatives guide
+          </Link>{" "}
+          instead.
         </p>
       </section>
 
       <section>
-        <h2>Why clickfolio.me Wins for Most People</h2>
+        <h2>The reviews</h2>
+
+        <h3>clickfolio.me — best for turning an existing resume into a hosted site for free</h3>
+        <p>
+          If you already have a PDF resume, clickfolio.me is the fastest way to get a hosted site
+          out of it. You upload the PDF, the AI reads it into structured sections, and about thirty
+          seconds later you have a live page at clickfolio.me/@yourhandle. There are ten templates
+          (six free, four unlocked through referrals rather than money), field-level privacy toggles
+          so you can hide a phone number or address, and built-in analytics. Hosting runs on
+          Cloudflare, and the project is open source under the MIT license.
+        </p>
+        <p>
+          The honest weaknesses: there is no custom-domain support yet, so every site lives on a
+          clickfolio.me/@handle URL for now. And the nicest four templates require you to refer
+          other people before they unlock. If a personal domain is a hard requirement today, one of
+          the paid tools below will serve you better. If free hosting and a thirty-second setup
+          matter more, start with{" "}
+          <Link href="/" className="text-brand font-semibold">
+            the builder
+          </Link>{" "}
+          and read{" "}
+          <Link href="/blog/how-to-make-a-resume-website" className="text-brand font-semibold">
+            how to make a resume website
+          </Link>{" "}
+          if you want the full walkthrough.
+        </p>
+
+        <h3>Standard Resume — clean recruiter-friendly web resume</h3>
+        <p>
+          Standard Resume builds a polished single-page web resume from your details and can pull
+          from a LinkedIn import to save typing. The templates look great in front of recruiters,
+          which is the whole point. The catch is that the web features sit behind the Pro plan at
+          $19/month, including the custom web-resume URL and view tracking. The free Basic tier is
+          usable, but the result is a web resume rather than a customizable portfolio with multiple
+          sections. Good fit if you want a tidy online version of your resume and do not mind the
+          monthly cost.
+        </p>
+
+        <h3>Carrd — cheap and flexible, but you design everything</h3>
+        <p>
+          Carrd is a general one-page site builder, not a resume tool. You get three sites free on a
+          Carrd subdomain with light branding, and a custom domain starts at $19/year on the Pro
+          Standard plan (the $9/year Pro Lite tier does not include a custom domain). It is
+          genuinely cheap and very flexible. The trade-off is that there is no resume import at all.
+          You start from a blank canvas and lay out every block yourself, so plan for an afternoon
+          of design work if you go this route.
+        </p>
+
+        <h3>Super.so — fast pages if you already live in Notion</h3>
+        <p>
+          Super.so turns a Notion workspace into a website, so if your resume and projects already
+          live in Notion, you can publish quickly and keep editing in a tool you know. Free sites
+          run on a super.site subdomain with a small badge, and a custom domain starts at $16/month
+          on the Personal plan. It is not resume-specific and it assumes you are comfortable
+          structuring content in Notion, which makes it a better fit for people who already use
+          Notion daily than for someone starting from a PDF.
+        </p>
+
+        <h3>Reactive Resume — free and private, but the output is a resume</h3>
+        <p>
+          Reactive Resume is a well-regarded open-source resume builder. It is free to use, you can
+          self-host it, and it imports from JSON or LinkedIn. For privacy-minded people who want
+          full control, it is hard to beat on principle. The thing to understand is what it
+          produces: a resume document or a shareable link and PDF, not a full portfolio site. The
+          hosted version has no custom domain, and a custom domain is only possible if you
+          self-host. Pick it if a clean, free resume is the goal rather than a website.
+        </p>
+
+        <h3>JSON Resume — an open standard for developers</h3>
+        <p>
+          JSON Resume is a community-built open standard: you describe your resume in a JSON file
+          and render it with any of 400-plus themes. It is free and refreshingly portable, since
+          your data is not locked into one company. It is also clearly a developer workflow built
+          around JSON, a CLI, and gists, with no polished AI parsing or PDF import. If you are
+          technical and want a format you fully own, it is excellent. Everyone else will find the
+          setup fiddly.
+        </p>
+
+        <h3>Kickresume — resume builder with a website add-on</h3>
+        <p>
+          Kickresume is primarily an AI resume builder with strong writing help and ATS-oriented
+          features, and it includes a one-click personal website option. There is a free plan, with
+          Premium starting around $8/month. The website is a secondary feature rather than the main
+          event, and custom-domain support is not clearly documented, since published sites appear
+          on a Kickresume URL. Worth a look if you want resume writing help first and a simple
+          website second.
+        </p>
+      </section>
+
+      <section>
+        <h2>How to choose</h2>
         <ul>
           <li>
-            <strong>10 templates</strong> — from ATS-optimized (ClassicATS) to bold creative
-            (NeoBrutalist) to developer-focused (DevTerminal). Something for every profession.
+            <strong>You already have a PDF resume and want it hosted for free:</strong> start with{" "}
+            <Link href="/" className="text-brand font-semibold">
+              clickfolio.me
+            </Link>
+            . Just know the URL stays on clickfolio.me/@handle for now.
           </li>
           <li>
-            <strong>Real web hosting</strong> — your site lives on Cloudflare's global edge network,
-            not a third-party subdomain. Fast load times everywhere.
+            <strong>You need a personal domain today:</strong> Carrd ($19/year) is the cheapest
+            path, with Standard Resume and Super.so as paid alternatives.
           </li>
           <li>
-            <strong>Privacy controls</strong> — granular toggles for phone, address, and directory
-            visibility. No other free tool offers this.
+            <strong>You want a resume document, not a website:</strong> Reactive Resume or JSON
+            Resume, both free and open source.
           </li>
           <li>
-            <strong>Free forever</strong> — core features are free. Premium templates unlock via
-            referrals, not a credit card.
+            <strong>You want help writing the resume itself:</strong> Kickresume leans into AI
+            writing and ATS checks.
           </li>
           <li>
-            <strong>AI parsing + editing</strong> — don't type anything. Upload your PDF, review the
-            AI output, and publish. Full editor available for changes.
-          </li>
-        </ul>
-      </section>
-
-      <section>
-        <h2>When to Choose Another Tool</h2>
-        <p>clickfolio.me isn't for everyone. Here's when alternatives might be better:</p>
-        <ul>
-          <li>
-            If you're a developer who wants complete code control and custom deployment, Magic Self
-            gives you that.
-          </li>
-          <li>
-            If your LinkedIn is your single source of truth and you never touch a PDF, DockPage's
-            import might be faster.
-          </li>
-          <li>
-            If you need a PDF resume (not a website), Reactive Resume builds beautiful documents.
-          </li>
-          <li>
-            If you have budget for a paid tool and design is your top priority, Refolio's templates
-            are gorgeous.
+            <strong>You came from Read.cv:</strong> it is gone, so see our{" "}
+            <Link href="/blog/read-cv-alternatives" className="text-brand font-semibold">
+              Read.cv alternatives guide
+            </Link>
+            .
           </li>
         </ul>
         <p>
-          For everyone else — especially if you already have a PDF resume — clickfolio.me is the
-          fastest path from document to live portfolio.
+          If your starting point is LinkedIn rather than a PDF, our guide on{" "}
+          <Link href="/blog/linkedin-to-portfolio" className="text-brand font-semibold">
+            turning a LinkedIn profile into a portfolio
+          </Link>{" "}
+          covers that path, and you can browse{" "}
+          <Link href="/explore" className="text-brand font-semibold">
+            real published sites
+          </Link>{" "}
+          to see what each style looks like in practice.
         </p>
       </section>
 
       <section>
-        <h2>Try It Yourself</h2>
+        <h2>Try it yourself</h2>
         <p>
-          The best way to compare tools is to try them. Upload your resume to clickfolio.me and see
-          what you get in 30 seconds. It's free, no credit card required, and you can delete your
-          account anytime.
+          The fastest way to compare these tools is to publish with one and judge the result. With a
+          PDF in hand, clickfolio.me gets you a live page in about thirty seconds, free, with no
+          credit card, and you can delete everything whenever you want.
         </p>
         <p>
           <Link href="/" className="text-brand font-semibold">
-            Upload your resume and build your portfolio →
+            Upload your resume and compare for yourself →
           </Link>
         </p>
       </section>

--- a/app/blog/cv-website-builder/page.tsx
+++ b/app/blog/cv-website-builder/page.tsx
@@ -1,0 +1,194 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
+import { getPostBySlug } from "@/lib/blog/posts";
+import { siteConfig } from "@/lib/config/site";
+
+export const revalidate = 3600;
+
+const post = getPostBySlug("cv-website-builder")!;
+const relatedPosts = ["best-resume-website-builders", "how-to-make-a-resume-website"]
+  .map((slug) => getPostBySlug(slug))
+  .filter(Boolean) as (typeof post)[];
+
+export function generateMetadata(): Metadata {
+  return {
+    title: post.title,
+    description: post.description,
+    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
+    openGraph: {
+      title: `${post.title} | ${siteConfig.fullName}`,
+      description: post.description,
+      siteName: siteConfig.fullName,
+      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
+    },
+    twitter: { card: "summary_large_image" },
+    robots: { index: true, follow: true },
+  };
+}
+
+export default function CvWebsiteBuilderPage() {
+  return (
+    <BlogPostLayout post={post} relatedPosts={relatedPosts}>
+      <section>
+        <h2>What is a CV website builder?</h2>
+        <p>
+          A CV website builder is a tool that turns your CV into a hosted web page you can share
+          with a link. The best ones read your existing CV and lay it out for you, so you don't
+          rebuild your career by hand. <Link href="/">clickfolio.me</Link> does exactly this: upload
+          a PDF, and it publishes a live site at <code>clickfolio.me/@yourhandle</code> in about 30
+          seconds, free.
+        </p>
+        <p>
+          There are two kinds of builders. Some give you a blank canvas and drag-and-drop blocks.
+          The faster kind imports your CV automatically and skips the typing. This guide covers what
+          to look for and how the options actually compare.
+        </p>
+      </section>
+
+      <section>
+        <h2>What features actually matter in a CV website builder?</h2>
+        <p>
+          Most builders list dozens of features. Only a few change whether you finish and whether
+          the result helps you get hired:
+        </p>
+        <ul>
+          <li>
+            <strong>CV import.</strong> Can it read your PDF and fill the page for you, or do you
+            retype everything? Import is the single biggest time-saver.
+          </li>
+          <li>
+            <strong>Free hosting and a real URL.</strong> A site you can't share isn't a site. Check
+            whether the link is free or paywalled.
+          </li>
+          <li>
+            <strong>Mobile-ready templates.</strong> Recruiters open links on phones. The layout has
+            to hold up on a small screen.
+          </li>
+          <li>
+            <strong>Editing without code.</strong> You should be able to fix a job title or reorder
+            sections in seconds.
+          </li>
+          <li>
+            <strong>Privacy controls and analytics.</strong> Decide who sees your contact details,
+            and see how many people viewed your page.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>How do CV website builders compare?</h2>
+        <p>
+          Here's an honest look at common options. The right pick depends on whether you value speed
+          or a hand-built design.
+        </p>
+        <div className="overflow-x-auto my-8 not-prose">
+          <table className="w-full border-collapse overflow-hidden rounded-lg border border-border text-sm">
+            <thead>
+              <tr>
+                <th className="border border-border p-3 text-left font-semibold">Tool</th>
+                <th className="border border-border p-3 text-left font-semibold">
+                  Imports your CV?
+                </th>
+                <th className="border border-border p-3 text-left font-semibold">Cost</th>
+                <th className="border border-border p-3 text-left font-semibold">Best for</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td className="border border-border p-3">clickfolio.me</td>
+                <td className="border border-border p-3">Yes — AI reads your PDF</td>
+                <td className="border border-border p-3">Free</td>
+                <td className="border border-border p-3">
+                  Turning an existing CV into a site fast
+                </td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">Carrd</td>
+                <td className="border border-border p-3">No — build by hand</td>
+                <td className="border border-border p-3">~$19/yr for a custom domain</td>
+                <td className="border border-border p-3">Hand-built one-page sites</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">General site builders</td>
+                <td className="border border-border p-3">No</td>
+                <td className="border border-border p-3">Often paid plans</td>
+                <td className="border border-border p-3">Full design control, more setup</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p>
+          Carrd is genuinely good and cheap if you want to design a page block by block, and $19/yr
+          for a custom domain is fair. But it won't read your CV — you build everything yourself.
+          clickfolio.me trades some design freedom for speed: it imports the PDF and hosts the
+          result free. For a fuller breakdown, see our{" "}
+          <Link href="/blog/best-resume-website-builders">
+            comparison of resume website builders
+          </Link>
+          .
+        </p>
+      </section>
+
+      <section>
+        <h2>How do you turn your CV into a website?</h2>
+        <p>With an AI builder, the process is short:</p>
+        <ol className="list-decimal pl-6 space-y-2">
+          <li>
+            <strong>Export your CV as a PDF.</strong> Use the version you already send to employers.
+          </li>
+          <li>
+            <strong>Upload it.</strong> The parser extracts your roles, education, skills, and
+            contact info.
+          </li>
+          <li>
+            <strong>Choose a template and edit.</strong> Pick from 10 designs and fix anything the
+            parser missed.
+          </li>
+          <li>
+            <strong>Publish and share.</strong> Your site is live at a clean handle you can paste
+            anywhere.
+          </li>
+        </ol>
+        <p>
+          If you'd rather see the full manual walkthrough, our{" "}
+          <Link href="/blog/how-to-make-a-resume-website">
+            step-by-step guide to making a resume website
+          </Link>{" "}
+          covers both paths.
+        </p>
+      </section>
+
+      <section>
+        <h2>Are CV website builders free?</h2>
+        <p>
+          Some are. clickfolio.me is free forever for its core features — hosting, AI import, 10
+          templates, privacy controls, and analytics. There's no paid tier; premium templates unlock
+          through referrals, not payment. Many other tools call themselves free but charge for the
+          parts you need: a custom domain, branding removal, or extra pages.
+        </p>
+        <p>
+          One honest limit: custom domains aren't available on clickfolio.me yet. Your site lives at{" "}
+          <code>clickfolio.me/@yourhandle</code>, which is on the roadmap to expand. For job
+          applications and outreach, a clean handle does the job — and it costs nothing to claim
+          yours.
+        </p>
+      </section>
+
+      <section>
+        <h2>Which builder should you choose?</h2>
+        <p>
+          If you want maximum design control and enjoy building pages, a hand-built tool like Carrd
+          is a solid, affordable pick. If you want a professional CV site without the work, upload
+          your PDF to clickfolio.me and you're done in under a minute. The fact that it's free and
+          open source (MIT, hosted on Cloudflare) means there's little downside to trying it first.
+        </p>
+        <p>
+          <Link href="/" className="text-brand font-semibold">
+            Turn your CV into a website for free →
+          </Link>
+        </p>
+      </section>
+    </BlogPostLayout>
+  );
+}

--- a/app/blog/how-to-make-a-resume-website/page.tsx
+++ b/app/blog/how-to-make-a-resume-website/page.tsx
@@ -1,0 +1,220 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
+import { getPostBySlug } from "@/lib/blog/posts";
+import { siteConfig } from "@/lib/config/site";
+
+export const revalidate = 3600;
+
+const post = getPostBySlug("how-to-make-a-resume-website")!;
+const relatedPosts = ["pdf-resume-to-website", "cv-website-builder"]
+  .map((slug) => getPostBySlug(slug))
+  .filter(Boolean) as (typeof post)[];
+
+export function generateMetadata(): Metadata {
+  return {
+    title: post.title,
+    description: post.description,
+    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
+    openGraph: {
+      title: `${post.title} | ${siteConfig.fullName}`,
+      description: post.description,
+      siteName: siteConfig.fullName,
+      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
+    },
+    twitter: { card: "summary_large_image" },
+    robots: { index: true, follow: true },
+  };
+}
+
+export default function HowToMakeAResumeWebsitePage() {
+  return (
+    <BlogPostLayout post={post} relatedPosts={relatedPosts}>
+      <section>
+        <h2>How do you make a resume website?</h2>
+        <p>
+          To make a resume website, upload your resume PDF to an AI builder, let it read your
+          experience and skills, pick a template, then publish to a shareable link. With{" "}
+          <Link href="/">clickfolio.me</Link> the whole thing takes about 30 seconds and costs
+          nothing. No coding, no design work, no retyping your career into a form.
+        </p>
+        <p>
+          The slow way still works too: write the content, choose a layout, build the page, and host
+          it yourself. Below is both the fast path and the manual path, so you can pick the one that
+          fits how much time you want to spend.
+        </p>
+      </section>
+
+      <section>
+        <h2>The fastest way: turn your resume PDF into a site</h2>
+        <p>
+          If you already have a resume, you have everything you need. Here are the steps, start to
+          finish:
+        </p>
+        <ol className="list-decimal pl-6 space-y-2">
+          <li>
+            <strong>Export your resume as a PDF.</strong> Use the resume you already send to
+            employers. If you only have a LinkedIn profile, open it, click "More," and choose "Save
+            to PDF."
+          </li>
+          <li>
+            <strong>Upload the PDF.</strong> Drop it into clickfolio.me. The AI reads your work
+            history, education, skills, and contact details and maps them onto the page for you.
+          </li>
+          <li>
+            <strong>Pick a template.</strong> Choose from 10 designs — clean and minimal for
+            corporate roles, bolder layouts for creative ones. You can switch any time without
+            losing content.
+          </li>
+          <li>
+            <strong>Review and edit.</strong> Fix any detail the parser missed, reorder sections,
+            and tighten your headline. This is the only manual part, and it's fast.
+          </li>
+          <li>
+            <strong>Publish.</strong> Your site goes live at <code>clickfolio.me/@yourhandle</code>.
+            Copy the link into your applications, email signature, and LinkedIn.
+          </li>
+        </ol>
+        <p>
+          That's it. You skip the blank page entirely because your resume already contains the
+          content — the builder just rebuilds it as a web page.
+        </p>
+      </section>
+
+      <section>
+        <h2>What should a resume website include?</h2>
+        <p>
+          Recruiters spend about 7.4 seconds on a first resume scan (The Ladders eye-tracking study,
+          2018), so your site has to answer "who is this and are they a fit?" before anyone scrolls.
+          Lead with the essentials:
+        </p>
+        <ul>
+          <li>
+            <strong>Name and headline.</strong> Your name, current role or target role, and one line
+            on what you do.
+          </li>
+          <li>
+            <strong>Summary.</strong> Two or three sentences on your focus and strongest results.
+          </li>
+          <li>
+            <strong>Experience.</strong> Roles with outcomes, not just duties. Numbers beat
+            adjectives.
+          </li>
+          <li>
+            <strong>Skills.</strong> The tools and abilities that match the jobs you want.
+          </li>
+          <li>
+            <strong>Projects or work samples.</strong> Especially useful for engineers, designers,
+            and writers.
+          </li>
+          <li>
+            <strong>Contact.</strong> One obvious way to reach you, plus links to relevant profiles.
+          </li>
+        </ul>
+        <p>
+          If you want to see how this looks in practice, browse the{" "}
+          <Link href="/explore">live examples on Explore</Link> before you build your own.
+        </p>
+      </section>
+
+      <section>
+        <h2>Should you build it yourself or use a builder?</h2>
+        <p>
+          Both produce a real website. The difference is how much time and skill you spend getting
+          there.
+        </p>
+        <div className="overflow-x-auto my-8 not-prose">
+          <table className="w-full border-collapse overflow-hidden rounded-lg border border-border text-sm">
+            <thead>
+              <tr>
+                <th className="border border-border p-3 text-left font-semibold">Approach</th>
+                <th className="border border-border p-3 text-left font-semibold">Time</th>
+                <th className="border border-border p-3 text-left font-semibold">Coding needed</th>
+                <th className="border border-border p-3 text-left font-semibold">Cost</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td className="border border-border p-3">Upload PDF to clickfolio.me</td>
+                <td className="border border-border p-3">~30 seconds</td>
+                <td className="border border-border p-3">None</td>
+                <td className="border border-border p-3">Free</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">Drag-and-drop site builder</td>
+                <td className="border border-border p-3">A few hours</td>
+                <td className="border border-border p-3">None</td>
+                <td className="border border-border p-3">Often paid for a custom URL</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">Code it from scratch</td>
+                <td className="border border-border p-3">Days</td>
+                <td className="border border-border p-3">Yes</td>
+                <td className="border border-border p-3">Hosting + your time</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p>
+          Coding your own site is worth it if you're a developer who wants total control and treats
+          the site as a portfolio piece in itself. For everyone else, importing a PDF gets you a
+          professional result without the work. If you want to weigh specific tools, see our{" "}
+          <Link href="/blog/best-resume-website-builders">
+            comparison of resume website builders
+          </Link>
+          .
+        </p>
+      </section>
+
+      <section>
+        <h2>How to pick your URL and keep it professional</h2>
+        <p>
+          Your link is the part people actually see and remember. A clean handle like{" "}
+          <code>clickfolio.me/@yourname</code> reads well on a resume, in an email signature, and on
+          LinkedIn. Custom domains aren't available yet — they're on the roadmap — but a tidy handle
+          is more than credible enough for applications and outreach today.
+        </p>
+        <p>
+          Keep the handle short, use your real name where you can, and reuse the same handle across
+          platforms so people find the right you. The goal is a single link you can paste anywhere
+          without explaining it.
+        </p>
+      </section>
+
+      <section>
+        <h2>After you publish: make the site work for you</h2>
+        <p>
+          Publishing is the start, not the finish. Once your site is live, put the link everywhere a
+          PDF used to go: applications, your LinkedIn "Featured" section, your email signature, and
+          your social bios. A site nobody can find doesn't help you.
+        </p>
+        <p>
+          clickfolio.me includes built-in analytics, so you can see how many people viewed your page
+          — something a PDF attachment can never tell you. You also control privacy: hide contact
+          details, unlist the page, or keep it fully public. And because the project is open source
+          (MIT) and hosted on Cloudflare, your site is fast and you can verify exactly how it works.
+        </p>
+        <p>
+          If you're an engineer and want role-specific guidance, our{" "}
+          <Link href="/for/software-engineer">guide for software engineers</Link> covers what to
+          highlight.
+        </p>
+      </section>
+
+      <section>
+        <h2>The short version</h2>
+        <p>
+          Making a resume website used to mean choosing between a weekend of design work and a
+          monthly subscription. It doesn't anymore. If you have a PDF, you're 30 seconds from a
+          hosted site you control, for free. Write the content well, pick a template that fits your
+          field, claim a clean handle, and share the link.
+        </p>
+        <p>
+          <Link href="/" className="text-brand font-semibold">
+            Upload your resume and build your site in 30 seconds →
+          </Link>
+        </p>
+      </section>
+    </BlogPostLayout>
+  );
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -17,13 +17,13 @@ import {
 /** Revalidate blog listing every 30 minutes for fresh content. */
 export const revalidate = 1800;
 
-const blogTitle = `Blog | ${siteConfig.fullName}`;
+const blogTitle = `Resume Website & Portfolio Guides | ${siteConfig.fullName}`;
 const blogDescription =
-  "Guides, comparisons, and tips for building your online portfolio. Learn how to turn your PDF resume into a professional website.";
+  "Guides, comparisons, and tips on building a resume website and online portfolio. Compare builders, see examples, and learn how to turn your PDF resume into a site.";
 
 /** SEO metadata for the blog listing page. */
 export const metadata: Metadata = {
-  title: "Blog",
+  title: "Resume Website & Portfolio Guides",
   description: blogDescription,
   alternates: { canonical: `${siteConfig.url}/blog` },
   openGraph: {

--- a/app/blog/personal-resume-website/page.tsx
+++ b/app/blog/personal-resume-website/page.tsx
@@ -1,0 +1,201 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
+import { getPostBySlug } from "@/lib/blog/posts";
+import { siteConfig } from "@/lib/config/site";
+
+export const revalidate = 3600;
+
+const post = getPostBySlug("personal-resume-website")!;
+const relatedPosts = ["resume-website-vs-linkedin", "pdf-resume-to-website"]
+  .map((slug) => getPostBySlug(slug))
+  .filter(Boolean) as (typeof post)[];
+
+export function generateMetadata(): Metadata {
+  return {
+    title: post.title,
+    description: post.description,
+    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
+    openGraph: {
+      title: `${post.title} | ${siteConfig.fullName}`,
+      description: post.description,
+      siteName: siteConfig.fullName,
+      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
+    },
+    twitter: { card: "summary_large_image" },
+    robots: { index: true, follow: true },
+  };
+}
+
+export default function PersonalResumeWebsitePage() {
+  return (
+    <BlogPostLayout post={post} relatedPosts={relatedPosts}>
+      <section>
+        <p>
+          A personal resume website is a web page you own that presents your career — experience,
+          skills, projects, and contact info — at your own URL. Unlike a PDF, it's always current
+          and shareable with a single link. Unlike LinkedIn, you control the design, the content,
+          and the analytics. It's the professional home base that everything else points to.
+        </p>
+        <p>
+          Most people have a resume PDF and a LinkedIn profile and assume that's enough. It usually
+          isn't. Here's what a personal resume website actually does for you, and how to make one
+          free without touching code.
+        </p>
+      </section>
+
+      <section>
+        <h2>What is a personal resume website?</h2>
+        <p>
+          Think of it as the live, web-native version of your resume. Instead of attaching a file or
+          sending someone to a profile that looks like everyone else's, you share one link that
+          opens a fast, well-designed page about you. It holds the same information a resume does —
+          but it's easier to read, works on any device, and never sits stale in a downloads folder.
+        </p>
+        <p>
+          The "personal" part matters. The site is yours. You decide what's on it, how it looks, and
+          who you send it to. No algorithm ranks it. No platform can change its layout overnight.
+        </p>
+      </section>
+
+      <section>
+        <h2>Why you need one in 2026</h2>
+        <p>
+          Employers look you up online before they ever reply. A personal site shapes what they
+          find:
+        </p>
+        <ul>
+          <li>
+            <strong>You control the first impression.</strong> A 2017 CareerBuilder/Harris Poll
+            survey found 70% of employers research candidates online during hiring. A polished site
+            decides what that search turns up.
+          </li>
+          <li>
+            <strong>It's a professional link for everything.</strong> Applications, your email
+            signature, your LinkedIn headline, a business card. One URL, always ready.
+          </li>
+          <li>
+            <strong>It can rank for your name.</strong> With your name in the URL, title, and
+            headings, your site can show up when someone Googles you — and build its own authority
+            over time.
+          </li>
+          <li>
+            <strong>You see who's interested.</strong> Built-in analytics tell you how many people
+            viewed your page. A PDF attachment tells you nothing.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Personal website vs PDF vs LinkedIn</h2>
+        <div className="overflow-x-auto my-8 not-prose">
+          <table className="w-full border-collapse overflow-hidden rounded-lg border border-border text-sm">
+            <thead>
+              <tr>
+                <th className="border border-border p-3 text-left font-semibold">Feature</th>
+                <th className="border border-border p-3 text-left font-semibold">Personal site</th>
+                <th className="border border-border p-3 text-left font-semibold">PDF resume</th>
+                <th className="border border-border p-3 text-left font-semibold">LinkedIn</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td className="border border-border p-3">You own it</td>
+                <td className="border border-border p-3">Yes</td>
+                <td className="border border-border p-3">Yes</td>
+                <td className="border border-border p-3">No (rented)</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">Custom design</td>
+                <td className="border border-border p-3">Yes</td>
+                <td className="border border-border p-3">Limited</td>
+                <td className="border border-border p-3">No</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">Always current</td>
+                <td className="border border-border p-3">Yes, edit anytime</td>
+                <td className="border border-border p-3">No, goes stale</td>
+                <td className="border border-border p-3">Yes</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">Ranks for your name</td>
+                <td className="border border-border p-3">Yes</td>
+                <td className="border border-border p-3">No</td>
+                <td className="border border-border p-3">Shared domain only</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">View analytics</td>
+                <td className="border border-border p-3">Yes</td>
+                <td className="border border-border p-3">No</td>
+                <td className="border border-border p-3">Partial</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p>
+          None of these replaces the others. Keep the PDF for ATS uploads, keep LinkedIn for
+          networking, and use your personal site as the full, curated story. For a deeper look at
+          the trade-offs, read{" "}
+          <Link href="/blog/resume-website-vs-linkedin">resume website vs LinkedIn</Link>.
+        </p>
+      </section>
+
+      <section>
+        <h2>What to put on your personal resume website</h2>
+        <ol className="list-decimal pl-6 space-y-2">
+          <li>
+            <strong>A hero with your name and role.</strong> Plus a one-line summary of what you do.
+          </li>
+          <li>
+            <strong>Experience with outcomes.</strong> Lead with results, not just responsibilities.
+          </li>
+          <li>
+            <strong>Skills.</strong> Grouped and honest — the tools and areas you actually work in.
+          </li>
+          <li>
+            <strong>Projects or portfolio links.</strong> Proof of the work behind the claims.
+          </li>
+          <li>
+            <strong>Education and credentials.</strong> Brief, unless they're central to your field.
+          </li>
+          <li>
+            <strong>Contact.</strong> One clear way to reach you.
+          </li>
+        </ol>
+        <p>Keep it scannable. Recruiters skim before they read, so make the important parts pop.</p>
+      </section>
+
+      <section>
+        <h2>How to make one free</h2>
+        <p>
+          You don't need to design or code anything. Upload your resume PDF to{" "}
+          <Link href="/">clickfolio.me</Link> and the AI reads your experience, education, and
+          skills, then rebuilds them on a professional template. Review the result, pick one of 10
+          layouts, and publish at clickfolio.me/@yourname in about 30 seconds. It's free forever,
+          with privacy controls and built-in analytics. If you already have a PDF, the{" "}
+          <Link href="/blog/pdf-resume-to-website">PDF resume to website</Link> guide shows exactly
+          how the conversion works.
+        </p>
+        <p>
+          One honest note: every site lives at clickfolio.me/@yourname. Custom domains aren't
+          available yet — they're on the roadmap — but a clean handle URL is plenty professional for
+          applications and your LinkedIn.
+        </p>
+      </section>
+
+      <section>
+        <h2>Own your professional presence</h2>
+        <p>
+          A personal resume website is the one professional asset you fully control. It outlasts any
+          single job, any platform, and any algorithm change — and it's working for you every time
+          someone looks you up. The setup cost is minutes; the upside compounds for years.
+        </p>
+        <p>
+          <Link href="/" className="text-brand font-semibold">
+            Upload your resume and build your site →
+          </Link>
+        </p>
+      </section>
+    </BlogPostLayout>
+  );
+}

--- a/app/blog/product-manager-portfolio-website/page.tsx
+++ b/app/blog/product-manager-portfolio-website/page.tsx
@@ -1,0 +1,211 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
+import { getPostBySlug } from "@/lib/blog/posts";
+import { siteConfig } from "@/lib/config/site";
+
+export const revalidate = 3600;
+
+const post = getPostBySlug("product-manager-portfolio-website")!;
+const relatedPosts = ["resume-website-examples", "best-resume-website-builders"]
+  .map((slug) => getPostBySlug(slug))
+  .filter(Boolean) as (typeof post)[];
+
+export function generateMetadata(): Metadata {
+  return {
+    title: post.title,
+    description: post.description,
+    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
+    openGraph: {
+      title: `${post.title} | ${siteConfig.fullName}`,
+      description: post.description,
+      siteName: siteConfig.fullName,
+      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
+    },
+    twitter: { card: "summary_large_image" },
+    robots: { index: true, follow: true },
+  };
+}
+
+export default function ProductManagerPortfolioWebsitePage() {
+  return (
+    <BlogPostLayout post={post} relatedPosts={relatedPosts}>
+      <section>
+        <h2>What is a product manager portfolio website?</h2>
+        <p>
+          A product manager portfolio website is a hosted page that shows how you think, not just
+          what you shipped. It walks recruiters through the problems you found, the decisions you
+          made, and the outcomes you drove. A resume lists your titles. A portfolio proves your
+          judgment.
+        </p>
+        <p>
+          That distinction matters because PM hiring is a judgment test. Anyone can claim they
+          "owned a roadmap." A portfolio lets a hiring manager watch you reason: how you framed a
+          problem, what you cut, and why your bet paid off. That is the case you can't make in six
+          bullet points.
+        </p>
+      </section>
+
+      <section>
+        <h2>Do product managers really need a portfolio?</h2>
+        <p>
+          More and more, yes. PM roles attract hundreds of applicants who all have similar resumes:
+          a few shipped features, a metric or two, the right keywords. Recruiters spend about{" "}
+          <strong>7.4 seconds</strong> on an initial resume scan (The Ladders eye-tracking, 2018),
+          so you have almost no time to separate yourself on paper.
+        </p>
+        <p>
+          A portfolio gives you a second surface — one you control. When a recruiter is interested
+          enough to click your link, you get their full attention for the first time. That is where
+          a strong case study turns a "maybe" into an interview. You don't need a portfolio to
+          apply. You need one to stand out once you do.
+        </p>
+      </section>
+
+      <section>
+        <h2>What should a product manager portfolio include?</h2>
+        <p>
+          The goal is to show your product thinking end to end. A strong PM portfolio usually
+          includes:
+        </p>
+        <ul>
+          <li>
+            <strong>A short positioning statement.</strong> One or two lines on the kind of products
+            you build, the stage you thrive in, and the outcomes you care about.
+          </li>
+          <li>
+            <strong>Two or three case studies.</strong> Depth beats breadth. A few deep stories
+            prove more than a long list of shallow ones.
+          </li>
+          <li>
+            <strong>Measurable outcomes.</strong> Activation, retention, revenue, time-to-ship —
+            whatever your work actually moved. Numbers earn trust.
+          </li>
+          <li>
+            <strong>Your process.</strong> How you discover problems, validate them, and prioritize.
+            This is the part interviewers probe hardest.
+          </li>
+          <li>
+            <strong>Skills and tools.</strong> Discovery methods, analytics, experimentation, and
+            the cross-functional work you led.
+          </li>
+          <li>
+            <strong>A clear way to reach you.</strong> Email and LinkedIn, easy to find.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>How do you structure a PM case study?</h2>
+        <p>Treat each case study like a product decision you can defend. A reliable structure:</p>
+        <ol className="list-decimal pl-6 space-y-2">
+          <li>
+            <strong>The problem and who had it.</strong> Name the user and the pain. Make the stakes
+            obvious before you mention any feature.
+          </li>
+          <li>
+            <strong>The evidence.</strong> The research, data, and signals that told you this was
+            worth solving. Show that you didn't guess.
+          </li>
+          <li>
+            <strong>The decision.</strong> What you prioritized, what you cut, and the tradeoff you
+            accepted. This is where your judgment shows.
+          </li>
+          <li>
+            <strong>The work.</strong> What you actually shipped, plus how you aligned engineering,
+            design, and stakeholders to get there.
+          </li>
+          <li>
+            <strong>The outcome.</strong> The measurable result, what you learned, and what you'd do
+            differently. Honesty about a miss often reads stronger than a flawless win.
+          </li>
+        </ol>
+        <p>
+          Building these out is real work — and that effort pays off twice. The writing forces you
+          to sharpen your own story, so you walk into interviews able to defend every decision. The
+          portfolio you assemble yourself is one you're proud to send, because you know exactly
+          what's behind every line.
+        </p>
+      </section>
+
+      <section>
+        <h2>How do I build a PM portfolio if my work is under NDA?</h2>
+        <p>
+          This stops a lot of PMs before they start, but it's a smaller problem than it looks. You
+          can show your thinking without leaking anything confidential:
+        </p>
+        <ul>
+          <li>
+            <strong>Use ranges, not exact figures.</strong> "Improved activation by roughly 20–30%"
+            communicates impact without exposing internal numbers.
+          </li>
+          <li>
+            <strong>Describe the problem space generically.</strong> "A B2B onboarding flow with
+            high drop-off" tells the story without naming the product.
+          </li>
+          <li>
+            <strong>Lean on public work.</strong> Side projects, product teardowns, and analyses of
+            apps you admire all demonstrate your process with zero NDA risk.
+          </li>
+          <li>
+            <strong>Focus on reasoning over specifics.</strong> Interviewers care more about how you
+            decided than the exact metric you moved.
+          </li>
+        </ul>
+        <p>
+          A teardown of a product everyone knows can be as convincing as a confidential case study,
+          because it shows the same muscle: spotting a problem, weighing options, and arguing for a
+          path.
+        </p>
+      </section>
+
+      <section>
+        <h2>How to publish a product manager portfolio fast</h2>
+        <p>
+          You don't need to code or pay a designer. If you already have a resume, you can be live in
+          about 30 seconds:
+        </p>
+        <ol className="list-decimal pl-6 space-y-2">
+          <li>
+            <strong>Upload your resume PDF</strong> to <Link href="/">clickfolio.me</Link>. The AI
+            reads your experience, skills, and education and builds a structured site.
+          </li>
+          <li>
+            <strong>Pick a template.</strong> There are 10 to choose from, so you can match the tone
+            you want.
+          </li>
+          <li>
+            <strong>Add your case studies and outcomes</strong> in the editor, then refine the
+            wording.
+          </li>
+          <li>
+            <strong>Publish</strong> to <code>clickfolio.me/@yourhandle</code> and share the link.
+          </li>
+        </ol>
+        <p>
+          It's free forever — no paid tier — and built-in analytics show you how many people opened
+          your portfolio, so you can tell which applications actually got read. Custom domains
+          aren't available yet; your site lives at your clickfolio.me handle for now. If you want to
+          see how others structure theirs, browse{" "}
+          <Link href="/blog/resume-website-examples">resume website examples</Link> or read the role
+          guide for <Link href="/for/product-manager">product managers</Link> before you start.
+        </p>
+      </section>
+
+      <section>
+        <h2>Make your thinking the thing they remember</h2>
+        <p>
+          Every PM applicant has shipped something. Far fewer can show how they think. A portfolio
+          closes that gap, and the act of building it makes you a sharper candidate before you ever
+          send the link. Start with the resume you already have and turn it into a site you're proud
+          to share.
+        </p>
+        <p>
+          <Link href="/" className="text-brand font-semibold">
+            Turn your resume into a PM portfolio in about 30 seconds →
+          </Link>
+        </p>
+      </section>
+    </BlogPostLayout>
+  );
+}

--- a/app/blog/read-cv-alternatives/page.tsx
+++ b/app/blog/read-cv-alternatives/page.tsx
@@ -1,0 +1,207 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
+import { getPostBySlug } from "@/lib/blog/posts";
+import { siteConfig } from "@/lib/config/site";
+
+export const revalidate = 3600;
+
+const post = getPostBySlug("read-cv-alternatives")!;
+const relatedPosts = ["best-resume-website-builders", "linkedin-to-portfolio"]
+  .map((slug) => getPostBySlug(slug))
+  .filter(Boolean) as (typeof post)[];
+
+export function generateMetadata(): Metadata {
+  return {
+    title: post.title,
+    description: post.description,
+    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
+    openGraph: {
+      title: `${post.title} | ${siteConfig.fullName}`,
+      description: post.description,
+      siteName: siteConfig.fullName,
+      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
+    },
+    twitter: { card: "summary_large_image" },
+    robots: { index: true, follow: true },
+  };
+}
+
+export default function ReadCvAlternativesPage() {
+  return (
+    <BlogPostLayout post={post} relatedPosts={relatedPosts}>
+      <section>
+        <p>
+          The best Read.cv alternative depends on what you used it for. If you mainly hosted a clean
+          professional profile, a free resume website builder like{" "}
+          <Link href="/">clickfolio.me</Link> is the closest replacement — upload your resume PDF
+          and get a hosted site at clickfolio.me/@yourname in about 30 seconds. For hand-built
+          one-page sites, Carrd works. For a polished PDF-style resume, Standard Resume fits.
+        </p>
+        <p>
+          Read.cv built a loyal following of designers, engineers, and writers who wanted a calm,
+          well-designed place to show their work. Then it went away. This guide explains what
+          happened and walks you through moving your profile somewhere you control — without losing
+          momentum in your job search.
+        </p>
+      </section>
+
+      <section>
+        <h2>What happened to Read.cv?</h2>
+        <p>
+          Perplexity, the AI search company, acquired Read.cv on January 17, 2025. Shortly after,
+          the team announced it would wind the product down. Users were given a window to export
+          their data, which closed on May 16, 2025. The <code>.cv</code> domains and profiles
+          migrated to Hello.cv starting around January 31, 2025, and the original profile and
+          "Sites" features were discontinued.
+        </p>
+        <p>
+          If you still have a Read.cv export sitting in a folder, you're in good shape. If you
+          don't, you can rebuild from your existing resume — which is faster than it sounds.
+        </p>
+      </section>
+
+      <section>
+        <h2>What to look for in a replacement</h2>
+        <p>
+          Read.cv earned trust by doing a few things well. Use these as your checklist when picking
+          where to go next:
+        </p>
+        <ul>
+          <li>
+            <strong>A clean, hosted profile.</strong> One link you can drop into applications, your
+            email signature, and your LinkedIn.
+          </li>
+          <li>
+            <strong>Low effort to set up.</strong> You shouldn't have to retype your whole career to
+            get online again.
+          </li>
+          <li>
+            <strong>You own the content.</strong> After a shutdown, the last thing you want is to be
+            locked into another platform that might vanish.
+          </li>
+          <li>
+            <strong>It stays current.</strong> A live page you can edit beats a static PDF that goes
+            stale the moment you change jobs.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>The best Read.cv alternatives compared</h2>
+        <div className="overflow-x-auto my-8 not-prose">
+          <table className="w-full border-collapse overflow-hidden rounded-lg border border-border text-sm">
+            <thead>
+              <tr>
+                <th className="border border-border p-3 text-left font-semibold">Tool</th>
+                <th className="border border-border p-3 text-left font-semibold">Best for</th>
+                <th className="border border-border p-3 text-left font-semibold">Imports resume</th>
+                <th className="border border-border p-3 text-left font-semibold">Price</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td className="border border-border p-3">clickfolio.me</td>
+                <td className="border border-border p-3">A hosted resume site from your PDF</td>
+                <td className="border border-border p-3">Yes, AI parses your PDF</td>
+                <td className="border border-border p-3">Free</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">Standard Resume</td>
+                <td className="border border-border p-3">A clean resume + simple web version</td>
+                <td className="border border-border p-3">Partial (LinkedIn import)</td>
+                <td className="border border-border p-3">Free + paid plans</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">Carrd</td>
+                <td className="border border-border p-3">A hand-built one-page site</td>
+                <td className="border border-border p-3">No, you build it</td>
+                <td className="border border-border p-3">Free + ~$19/yr Pro</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">About.me</td>
+                <td className="border border-border p-3">A simple intro/bio page</td>
+                <td className="border border-border p-3">No</td>
+                <td className="border border-border p-3">Free + paid plans</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p>
+          One note: Bento.me, which some Read.cv users moved to, also shut down around February
+          2026. Skip it. Pick a tool that's stable and gives you a portable copy of your content.
+        </p>
+      </section>
+
+      <section>
+        <h2>Why a resume website builder is the closest match</h2>
+        <p>
+          Read.cv's core appeal was a single, good-looking page that summarized your professional
+          life. That's exactly what a resume website builder produces. With{" "}
+          <Link href="/">clickfolio.me</Link>, you upload your resume PDF and the AI reads your
+          experience, education, and skills, then rebuilds them as an editable page on one of 10
+          templates. You get a real URL, built-in view analytics, and privacy controls — and it's
+          free forever.
+        </p>
+        <p>
+          The honest limit: every site lives at clickfolio.me/@yourname. Custom domains aren't
+          available yet — they're on the roadmap. For most job seekers a clean hosted handle is more
+          than professional enough for applications and your LinkedIn profile. If you want to
+          compare your options first, our roundup of the{" "}
+          <Link href="/blog/best-resume-website-builders">best free resume website builders</Link>{" "}
+          breaks down each one.
+        </p>
+      </section>
+
+      <section>
+        <h2>How to migrate from Read.cv in three steps</h2>
+        <ol className="list-decimal pl-6 space-y-2">
+          <li>
+            <strong>Find your content.</strong> If you exported your Read.cv data before May 2025,
+            open it. If not, grab your most recent resume PDF — or export your LinkedIn profile as a
+            PDF, which works just as well.
+          </li>
+          <li>
+            <strong>Upload it.</strong> Drop the PDF into <Link href="/">clickfolio.me</Link>. The
+            AI parses it and builds your page in about 30 seconds. No retyping.
+          </li>
+          <li>
+            <strong>Review, pick a template, publish.</strong> Tidy any details the parser missed,
+            choose a layout, and publish. Then update the link everywhere your old Read.cv URL
+            lived: your resume, LinkedIn, GitHub, and email signature.
+          </li>
+        </ol>
+        <p>
+          If you came from LinkedIn rather than a resume file, our guide on turning your{" "}
+          <Link href="/blog/linkedin-to-portfolio">LinkedIn profile into a portfolio website</Link>{" "}
+          covers the export step in detail.
+        </p>
+      </section>
+
+      <section>
+        <h2>Don't leave the gap open</h2>
+        <p>
+          Every week your profile link points to a dead page is a week a recruiter, client, or
+          hiring manager hits a wall instead of your work. A personal website still pays off: in a
+          Workfolio survey reported by Forbes in 2013, 56% of hiring managers were more impressed by
+          a personal website than any other branding tool — yet only 7% of job seekers had one.
+          Rebuilding takes minutes, and you come out the other side owning your page instead of
+          renting it.
+        </p>
+      </section>
+
+      <section>
+        <h2>Ready to move?</h2>
+        <p>
+          Read.cv is gone, but your work isn't. Rebuild it somewhere you control and never worry
+          about another shutdown taking your profile down with it.
+        </p>
+        <p>
+          <Link href="/" className="text-brand font-semibold">
+            Upload your resume and build your site →
+          </Link>
+        </p>
+      </section>
+    </BlogPostLayout>
+  );
+}

--- a/app/blog/resume-hosting/page.tsx
+++ b/app/blog/resume-hosting/page.tsx
@@ -1,0 +1,188 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
+import { getPostBySlug } from "@/lib/blog/posts";
+import { siteConfig } from "@/lib/config/site";
+
+export const revalidate = 3600;
+
+const post = getPostBySlug("resume-hosting")!;
+const relatedPosts = ["pdf-resume-to-website", "personal-resume-website"]
+  .map((slug) => getPostBySlug(slug))
+  .filter(Boolean) as (typeof post)[];
+
+export function generateMetadata(): Metadata {
+  return {
+    title: post.title,
+    description: post.description,
+    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
+    openGraph: {
+      title: `${post.title} | ${siteConfig.fullName}`,
+      description: post.description,
+      siteName: siteConfig.fullName,
+      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
+    },
+    twitter: { card: "summary_large_image" },
+    robots: { index: true, follow: true },
+  };
+}
+
+export default function ResumeHostingPage() {
+  return (
+    <BlogPostLayout post={post} relatedPosts={relatedPosts}>
+      <section>
+        <h2>What is resume hosting?</h2>
+        <p>
+          Resume hosting means putting your resume online so you can share it with one link instead
+          of emailing a file. The best approach hosts your resume as a live web page, not a PDF on a
+          file server. <Link href="/">clickfolio.me</Link> hosts your resume as a website at{" "}
+          <code>clickfolio.me/@yourhandle</code> free, so the link is always current and you can see
+          who's viewing it.
+        </p>
+        <p>
+          A hosted resume beats an attachment in three ways: it's easier to share, it never goes
+          stale, and it can tell you whether anyone actually opened it. Here's how to set one up and
+          when to still send a PDF.
+        </p>
+      </section>
+
+      <section>
+        <h2>Where can you host your resume online for free?</h2>
+        <p>
+          You have a few options, and they're not equal. A file host stores a document; a resume
+          website hosts a page people can read on any device.
+        </p>
+        <ul>
+          <li>
+            <strong>Resume website (recommended).</strong> Tools like clickfolio.me turn your PDF
+            into a hosted page with a clean link, mobile layout, and analytics — free.
+          </li>
+          <li>
+            <strong>Cloud file storage.</strong> Google Drive or Dropbox can share a PDF link, but
+            visitors download a file instead of reading a page, and you get no real analytics.
+          </li>
+          <li>
+            <strong>Your own domain.</strong> Full control, but you handle hosting, design, and
+            upkeep yourself.
+          </li>
+        </ul>
+        <p>
+          For most people, a resume website is the sweet spot: free, professional, and zero
+          maintenance. If you want to understand the underlying conversion, see{" "}
+          <Link href="/blog/pdf-resume-to-website">how a PDF resume becomes a website</Link>.
+        </p>
+      </section>
+
+      <section>
+        <h2>How to host your resume in 30 seconds</h2>
+        <p>If you already have a resume PDF, hosting it is quick:</p>
+        <ol className="list-decimal pl-6 space-y-2">
+          <li>
+            <strong>Export your resume as a PDF.</strong> Use the copy you send to employers.
+          </li>
+          <li>
+            <strong>Upload it.</strong> The AI reads your experience, skills, and contact details
+            and builds the page.
+          </li>
+          <li>
+            <strong>Choose a template.</strong> Pick from 10 designs and adjust anything that needs
+            a fix.
+          </li>
+          <li>
+            <strong>Publish and copy your link.</strong> Your resume is live at a shareable handle
+            you can paste anywhere.
+          </li>
+        </ol>
+        <p>
+          That's the whole process. You upload once, and the link stays live — update the content
+          and the same URL always shows your latest version.
+        </p>
+      </section>
+
+      <section>
+        <h2>PDF attachment vs hosted resume link</h2>
+        <p>You don't have to choose one forever, but it helps to know what each is good at.</p>
+        <div className="overflow-x-auto my-8 not-prose">
+          <table className="w-full border-collapse overflow-hidden rounded-lg border border-border text-sm">
+            <thead>
+              <tr>
+                <th className="border border-border p-3 text-left font-semibold">Factor</th>
+                <th className="border border-border p-3 text-left font-semibold">PDF attachment</th>
+                <th className="border border-border p-3 text-left font-semibold">
+                  Hosted resume link
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td className="border border-border p-3">Sharing</td>
+                <td className="border border-border p-3">Attach a file each time</td>
+                <td className="border border-border p-3">One link, paste anywhere</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">Staying current</td>
+                <td className="border border-border p-3">Old copies float around</td>
+                <td className="border border-border p-3">Always shows the latest version</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">Analytics</td>
+                <td className="border border-border p-3">None</td>
+                <td className="border border-border p-3">See views and visits</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">Mobile reading</td>
+                <td className="border border-border p-3">Pinch and zoom</td>
+                <td className="border border-border p-3">Responsive page</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">ATS uploads</td>
+                <td className="border border-border p-3">Required by most systems</td>
+                <td className="border border-border p-3">Not a file upload</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p>
+          The takeaway: keep a PDF for applications that demand a file, and use a hosted link
+          everywhere else. Most application systems still want a PDF upload, so don't throw yours
+          away.
+        </p>
+      </section>
+
+      <section>
+        <h2>Can you track who views your hosted resume?</h2>
+        <p>
+          Yes — and it's one of the strongest reasons to host. clickfolio.me includes built-in
+          analytics, so you can see how many people viewed your page. A PDF sitting in someone's
+          inbox tells you nothing. With 70% of employers researching candidates online before hiring
+          (CareerBuilder/Harris Poll, 2017), knowing your link is getting opened is genuinely useful
+          signal.
+        </p>
+        <p>
+          You also stay in control of what's visible. Hide your contact details, keep the page
+          public, or unlist it — your call. Because clickfolio.me is open source (MIT) and runs on
+          Cloudflare, the page loads fast and you can verify how your data is handled.
+        </p>
+      </section>
+
+      <section>
+        <h2>Where to put your resume link</h2>
+        <p>
+          A hosted resume only helps if people find it. Once it's live, add the link to your job
+          applications, your email signature, your LinkedIn profile, and your social bios. If you're
+          deciding how a hosted resume fits alongside a full portfolio, our guide on{" "}
+          <Link href="/blog/personal-resume-website">personal resume websites</Link> goes deeper.
+        </p>
+        <p>
+          Stop attaching the same file over and over. Host it once, share one link, and watch the
+          views come in.
+        </p>
+        <p>
+          <Link href="/" className="text-brand font-semibold">
+            Host your resume free and get your shareable link →
+          </Link>
+        </p>
+      </section>
+    </BlogPostLayout>
+  );
+}

--- a/app/blog/resume-website-examples/page.tsx
+++ b/app/blog/resume-website-examples/page.tsx
@@ -1,0 +1,217 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
+import { getPostBySlug } from "@/lib/blog/posts";
+import { siteConfig } from "@/lib/config/site";
+
+export const revalidate = 3600;
+
+const post = getPostBySlug("resume-website-examples")!;
+const relatedPosts = ["clickfolio-templates-showcase", "how-to-make-a-resume-website"]
+  .map((slug) => getPostBySlug(slug))
+  .filter(Boolean) as (typeof post)[];
+
+export function generateMetadata(): Metadata {
+  return {
+    title: post.title,
+    description: post.description,
+    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
+    openGraph: {
+      title: `${post.title} | ${siteConfig.fullName}`,
+      description: post.description,
+      siteName: siteConfig.fullName,
+      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
+    },
+    twitter: { card: "summary_large_image" },
+    robots: { index: true, follow: true },
+  };
+}
+
+export default function ResumeWebsiteExamplesPage() {
+  return (
+    <BlogPostLayout post={post} relatedPosts={relatedPosts}>
+      <section>
+        <p>
+          A good resume website example loads fast, works on mobile, and leads with your name, role,
+          and strongest work above the fold. The best ones pick one clear layout, use readable type,
+          and give recruiters a single obvious way to get in touch. Below are the styles that work,
+          what makes each one effective, and how to build your own for free.
+        </p>
+        <p>
+          You don't need to copy any single site. You need to see the patterns that repeat across
+          good ones, then apply them to your own background. That's what these examples are for.
+        </p>
+      </section>
+
+      <section>
+        <h2>What makes a resume website example worth copying?</h2>
+        <p>Before the styles, here's the shortlist every strong example shares:</p>
+        <ul>
+          <li>
+            <strong>A clear hero.</strong> Name, current role, and a one-line summary you can read
+            in two seconds.
+          </li>
+          <li>
+            <strong>Scannable experience.</strong> Roles with outcomes, not just duties. Numbers
+            where you have them.
+          </li>
+          <li>
+            <strong>One focus per page.</strong> A designer shows craft; an engineer shows shipped
+            projects. They don't try to be everything.
+          </li>
+          <li>
+            <strong>Fast and mobile-friendly.</strong> Recruiters open links on their phones. A slow
+            or broken layout loses them.
+          </li>
+          <li>
+            <strong>An obvious contact path.</strong> Email or a button, not a buried footer.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Minimal resume website examples</h2>
+        <p>
+          Minimal sites win because they remove everything that competes with your content. Think
+          plenty of whitespace, one accent color, and a single readable typeface. The hero states
+          your name and role. Below it, experience and skills sit in clean sections with generous
+          spacing.
+        </p>
+        <p>
+          This style suits almost everyone — analysts, consultants, marketers, operations, finance.
+          It reads as confident and current. If you're unsure where to start, start here. A minimal
+          editorial layout makes average content look sharp and great content look exceptional.
+        </p>
+      </section>
+
+      <section>
+        <h2>Creative resume website examples</h2>
+        <p>
+          Creatives — designers, writers, art directors, photographers — can push further. Here the
+          site itself is a work sample. Bolder type, a distinctive color palette, and visible
+          project thumbnails do the talking. The risk is letting style bury substance, so the
+          strongest creative examples still answer the basics fast: who you are, what you make, and
+          how to reach you.
+        </p>
+        <p>
+          A useful rule: if a recruiter can't tell what you do within five seconds, the design is
+          working against you. Personality should frame your work, not hide it.
+        </p>
+      </section>
+
+      <section>
+        <h2>Developer resume website examples</h2>
+        <p>
+          Developer sites lead with shipped work. The best ones list projects with a short
+          description, the stack, and links to live demos or GitHub. Experience comes next, then
+          skills grouped by area. Clarity beats cleverness — a clean project list converts better
+          than an over-animated landing page.
+        </p>
+        <p>
+          If you're an engineer, our role-specific guide for the{" "}
+          <Link href="/for/software-engineer">software engineer portfolio</Link> covers exactly
+          which projects to feature and how to frame impact for technical hiring.
+        </p>
+      </section>
+
+      <section>
+        <h2>Resume website styles at a glance</h2>
+        <div className="overflow-x-auto my-8 not-prose">
+          <table className="w-full border-collapse overflow-hidden rounded-lg border border-border text-sm">
+            <thead>
+              <tr>
+                <th className="border border-border p-3 text-left font-semibold">Style</th>
+                <th className="border border-border p-3 text-left font-semibold">Best for</th>
+                <th className="border border-border p-3 text-left font-semibold">Leads with</th>
+                <th className="border border-border p-3 text-left font-semibold">Watch out for</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td className="border border-border p-3">Minimal</td>
+                <td className="border border-border p-3">Most professionals</td>
+                <td className="border border-border p-3">Name, role, summary</td>
+                <td className="border border-border p-3">Looking too plain — add one accent</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">Creative</td>
+                <td className="border border-border p-3">Designers, writers</td>
+                <td className="border border-border p-3">Visual work samples</td>
+                <td className="border border-border p-3">Style burying substance</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">Developer</td>
+                <td className="border border-border p-3">Engineers</td>
+                <td className="border border-border p-3">Projects + stack</td>
+                <td className="border border-border p-3">Over-animation, slow load</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">Corporate</td>
+                <td className="border border-border p-3">PMs, execs, finance</td>
+                <td className="border border-border p-3">Experience + outcomes</td>
+                <td className="border border-border p-3">Reading like a dull PDF</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p>
+          Want to see live layouts instead of descriptions? Browse the{" "}
+          <Link href="/explore">explore page</Link> for real published sites, and the{" "}
+          <Link href="/blog/clickfolio-templates-showcase">full template showcase</Link> to see all
+          10 designs side by side.
+        </p>
+      </section>
+
+      <section>
+        <h2>What every resume website should include</h2>
+        <p>Whatever style you pick, the content checklist is the same:</p>
+        <ol className="list-decimal pl-6 space-y-2">
+          <li>
+            <strong>Name and headline.</strong> Your current or target role in plain words.
+          </li>
+          <li>
+            <strong>Short summary.</strong> Two or three lines on what you do and the value you
+            bring.
+          </li>
+          <li>
+            <strong>Experience with outcomes.</strong> What changed because you were there.
+          </li>
+          <li>
+            <strong>Skills and tools.</strong> Grouped, scannable, honest.
+          </li>
+          <li>
+            <strong>Projects or work links.</strong> Proof, not just claims.
+          </li>
+          <li>
+            <strong>Contact.</strong> One clear way to reach you.
+          </li>
+        </ol>
+      </section>
+
+      <section>
+        <h2>How to build a site like these — free</h2>
+        <p>
+          You don't have to design from scratch to get an example-quality result. Upload your resume
+          PDF to <Link href="/">clickfolio.me</Link> and the AI reads your details, then applies a
+          professional template so your site comes out looking like the examples above in about 30
+          seconds. Pick the style that fits your field, adjust a few lines, and publish at
+          clickfolio.me/@yourname. If you'd rather follow each step, read{" "}
+          <Link href="/blog/how-to-make-a-resume-website">how to make a resume website</Link>.
+        </p>
+      </section>
+
+      <section>
+        <h2>Stop bookmarking examples — build yours</h2>
+        <p>
+          The examples that impress you took their owners minutes, not weekends. Yours can too. Skip
+          the blank-page problem and start from a template that already works.
+        </p>
+        <p>
+          <Link href="/" className="text-brand font-semibold">
+            Upload your resume and build your site →
+          </Link>
+        </p>
+      </section>
+    </BlogPostLayout>
+  );
+}

--- a/app/blog/resume-website-vs-linkedin/page.tsx
+++ b/app/blog/resume-website-vs-linkedin/page.tsx
@@ -1,0 +1,178 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
+import { getPostBySlug } from "@/lib/blog/posts";
+import { siteConfig } from "@/lib/config/site";
+
+export const revalidate = 3600;
+
+const post = getPostBySlug("resume-website-vs-linkedin")!;
+const relatedPosts = ["linkedin-to-portfolio", "personal-resume-website"]
+  .map((slug) => getPostBySlug(slug))
+  .filter(Boolean) as (typeof post)[];
+
+export function generateMetadata(): Metadata {
+  return {
+    title: post.title,
+    description: post.description,
+    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
+    openGraph: {
+      title: `${post.title} | ${siteConfig.fullName}`,
+      description: post.description,
+      siteName: siteConfig.fullName,
+      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
+    },
+    twitter: { card: "summary_large_image" },
+    robots: { index: true, follow: true },
+  };
+}
+
+export default function ResumeWebsiteVsLinkedinPage() {
+  return (
+    <BlogPostLayout post={post} relatedPosts={relatedPosts}>
+      <section>
+        <h2>Resume website or LinkedIn: which do you need?</h2>
+        <p>
+          You need both, because they do different jobs. LinkedIn gives you reach and recruiter
+          discovery on a network of about 1.3 billion users (2026). A resume website gives you
+          control, custom design, your own analytics, and a real shot at ranking in Google for your
+          name. One helps people find you; the other decides what they see.
+        </p>
+        <p>
+          Treating it as a choice is the mistake. The strongest setup uses LinkedIn for distribution
+          and a site you own for the full, curated story of your work.
+        </p>
+      </section>
+
+      <section>
+        <h2>How are a resume website and LinkedIn different?</h2>
+        <p>
+          They optimize for opposite things. LinkedIn optimizes for the network — its layout, its
+          algorithm, its features. A resume website optimizes for you. Here's how they compare on
+          the factors that affect a job search:
+        </p>
+        <div className="overflow-x-auto my-8 not-prose">
+          <table className="w-full border-collapse overflow-hidden rounded-lg border border-border text-sm">
+            <thead>
+              <tr>
+                <th className="border border-border p-3 text-left font-semibold">Factor</th>
+                <th className="border border-border p-3 text-left font-semibold">Resume website</th>
+                <th className="border border-border p-3 text-left font-semibold">LinkedIn</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td className="border border-border p-3">Ownership</td>
+                <td className="border border-border p-3">You own the page and its content</td>
+                <td className="border border-border p-3">LinkedIn owns and controls it</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">Design</td>
+                <td className="border border-border p-3">Your choice of template and layout</td>
+                <td className="border border-border p-3">Same look as every other profile</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">Reach</td>
+                <td className="border border-border p-3">You drive the traffic</td>
+                <td className="border border-border p-3">Built-in network of ~1.3B users</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">Recruiter discovery</td>
+                <td className="border border-border p-3">Limited without promotion</td>
+                <td className="border border-border p-3">Strong; recruiters search here</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">Google ranking for your name</td>
+                <td className="border border-border p-3">Strong with your name in the URL</td>
+                <td className="border border-border p-3">Competes with every other profile</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">Analytics</td>
+                <td className="border border-border p-3">Full view data on your visitors</td>
+                <td className="border border-border p-3">Partial, and gated by plan</td>
+              </tr>
+              <tr>
+                <td className="border border-border p-3">Cost</td>
+                <td className="border border-border p-3">Free on clickfolio.me</td>
+                <td className="border border-border p-3">Free; some features paid</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section>
+        <h2>What does a resume website do better?</h2>
+        <p>It gives you control of the things LinkedIn keeps for itself:</p>
+        <ul>
+          <li>
+            <strong>You own it.</strong> Your site doesn't disappear if a platform changes its rules
+            or removes a feature you relied on. What you build stays yours.
+          </li>
+          <li>
+            <strong>You design it.</strong> Pick from 10 templates and shape the layout. On LinkedIn
+            your profile looks like everyone else's.
+          </li>
+          <li>
+            <strong>You see real analytics.</strong> Know how many people opened your site and which
+            applications actually got read — not a partial, gated view.
+          </li>
+          <li>
+            <strong>You can rank for your name.</strong> A page with your name in the URL, title,
+            and headings has a real shot at appearing when someone Googles you.
+          </li>
+        </ul>
+        <p>
+          That last point compounds. Every visit and every link to your site builds its authority
+          over time, while a LinkedIn profile's ranking rides on LinkedIn's domain, not yours.
+        </p>
+      </section>
+
+      <section>
+        <h2>What does LinkedIn do better?</h2>
+        <p>
+          Reach and discovery, full stop. Recruiters live on LinkedIn and search it daily, and its
+          ~1.3 billion users make it the default place people look you up. You can't replicate that
+          network with a standalone site, and you shouldn't try. LinkedIn is how people find you
+          before they've ever heard your name.
+        </p>
+        <p>
+          The catch is that everything LinkedIn shows runs through its algorithm and its template.
+          You get the audience, but you give up the controls. That's exactly the gap a resume
+          website fills.
+        </p>
+      </section>
+
+      <section>
+        <h2>Why using both wins</h2>
+        <p>
+          Use LinkedIn to be discovered and to connect. Use your website as the destination — the
+          place you send anyone who wants the full story. LinkedIn is the introduction; your site is
+          the conversation. Put your site link in your LinkedIn Featured section, your contact info,
+          and your email signature, so the reach you get on LinkedIn flows to the page you control.
+        </p>
+        <p>
+          If your LinkedIn profile is your most current record, you can turn it into a site in
+          minutes — export it as a PDF and upload it. We walk through the exact steps in{" "}
+          <Link href="/blog/linkedin-to-portfolio">turning LinkedIn into a portfolio</Link>, and you
+          can see how a focused personal site is built in{" "}
+          <Link href="/blog/personal-resume-website">our guide to personal resume websites</Link>.
+        </p>
+      </section>
+
+      <section>
+        <h2>Claim the part you can own</h2>
+        <p>
+          You can't control LinkedIn, but you can control your own site — and the professionals who
+          stand out are the ones who own both ends of their presence. Keep LinkedIn for reach, and
+          build the page that's entirely yours.
+        </p>
+        <p>
+          <Link href="/" className="text-brand font-semibold">
+            Build the resume website you actually own →
+          </Link>
+        </p>
+      </section>
+    </BlogPostLayout>
+  );
+}

--- a/app/blog/student-resume-website/page.tsx
+++ b/app/blog/student-resume-website/page.tsx
@@ -1,0 +1,167 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
+import { getPostBySlug } from "@/lib/blog/posts";
+import { siteConfig } from "@/lib/config/site";
+
+export const revalidate = 3600;
+
+const post = getPostBySlug("student-resume-website")!;
+const relatedPosts = ["how-to-make-a-resume-website", "resume-writing-tips"]
+  .map((slug) => getPostBySlug(slug))
+  .filter(Boolean) as (typeof post)[];
+
+export function generateMetadata(): Metadata {
+  return {
+    title: post.title,
+    description: post.description,
+    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
+    openGraph: {
+      title: `${post.title} | ${siteConfig.fullName}`,
+      description: post.description,
+      siteName: siteConfig.fullName,
+      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
+    },
+    twitter: { card: "summary_large_image" },
+    robots: { index: true, follow: true },
+  };
+}
+
+export default function StudentResumeWebsitePage() {
+  return (
+    <BlogPostLayout post={post} relatedPosts={relatedPosts}>
+      <section>
+        <h2>Can a student make a resume website with no experience?</h2>
+        <p>
+          Yes. You don't need a job history to build a resume website — you need projects,
+          coursework, activities, and a clear way to show them. Upload a one-page resume PDF to a
+          free builder and you'll have a hosted site with a shareable link in about 30 seconds. No
+          coding, no cost.
+        </p>
+        <p>
+          Most students already have more to show than they think. The trick isn't inventing
+          experience. It's framing what you've already built and learned so a recruiter can see it
+          in seconds.
+        </p>
+      </section>
+
+      <section>
+        <h2>Should a student have a resume website?</h2>
+        <p>
+          It's one of the easiest ways to stand out for internships and entry-level roles. Most
+          students send a PDF and stop there. A clean link on your application, your LinkedIn, and
+          your career-fair conversations signals initiative and makes you easy to remember after a
+          recruiter has met 40 people in a day.
+        </p>
+        <p>
+          And it costs you nothing. A study from Workfolio found that 56% of hiring managers were
+          more impressed by a personal website than any other branding tool, yet only 7% of job
+          seekers had one (Forbes, 2013). For students, that gap is the opportunity: a small amount
+          of effort puts you in a category almost no one else bothers to enter.
+        </p>
+      </section>
+
+      <section>
+        <h2>What do I put on a student resume website with no work experience?</h2>
+        <p>
+          Lead with what you have, and frame it around what you built and learned. A strong student
+          site usually includes:
+        </p>
+        <ul>
+          <li>
+            <strong>Education.</strong> Your school, program, expected graduation, and relevant
+            coursework. GPA if it helps you.
+          </li>
+          <li>
+            <strong>Projects.</strong> Class projects, hackathons, personal builds, anything you
+            made. Say what the goal was, what you did, and what came of it.
+          </li>
+          <li>
+            <strong>Skills.</strong> Tools, languages, software, and methods you can actually use.
+          </li>
+          <li>
+            <strong>Activities and leadership.</strong> Clubs, teams, student government, organizing
+            — these show ownership and follow-through.
+          </li>
+          <li>
+            <strong>Volunteering and part-time work.</strong> A campus job or tutoring gig
+            demonstrates reliability and real responsibility.
+          </li>
+          <li>
+            <strong>Freelance or personal work.</strong> A side project, a small client, a blog, a
+            design you shipped. All of it counts.
+          </li>
+        </ul>
+        <p>
+          Notice that none of this requires a past internship. "No experience" usually means "no job
+          title" — and a resume website is the format that lets your projects and coursework carry
+          the weight instead.
+        </p>
+      </section>
+
+      <section>
+        <h2>How do I describe projects and coursework convincingly?</h2>
+        <p>
+          Use the same shape professionals use for jobs: what was the goal, what did you do, and
+          what was the result. For a class project, that might be "Built a budgeting app for a
+          software course; led the database design; the team scored in the top three of 30." For a
+          club, it might be "Organized a 200-person event; managed a $2,000 budget; grew turnout 40%
+          over the prior year."
+        </p>
+        <p>
+          Specifics beat adjectives. "Hard-working team player" tells a recruiter nothing.
+          "Coordinated five volunteers and shipped the event on time" shows it. For more on
+          phrasing, see our <Link href="/blog/resume-writing-tips">resume writing tips</Link>.
+        </p>
+      </section>
+
+      <section>
+        <h2>How to make a free student resume website</h2>
+        <p>You don't need design or coding skills. The fastest path:</p>
+        <ol className="list-decimal pl-6 space-y-2">
+          <li>
+            <strong>Write a one-page resume PDF.</strong> List your education, projects, skills, and
+            activities. Even a rough draft is enough to start.
+          </li>
+          <li>
+            <strong>
+              Upload it to <Link href="/">clickfolio.me</Link>.
+            </strong>{" "}
+            The AI reads your PDF and builds a structured site automatically.
+          </li>
+          <li>
+            <strong>Pick a template.</strong> Choose from 10 designs to match the field you're
+            applying into.
+          </li>
+          <li>
+            <strong>Review and publish.</strong> Tidy up the wording in the editor and go live at{" "}
+            <code>clickfolio.me/@yourhandle</code>.
+          </li>
+        </ol>
+        <p>
+          It's free forever — there's no paid tier — and you control what's visible. Built-in
+          analytics even show how many people opened your site, which is oddly motivating during an
+          internship hunt. Custom domains aren't available yet, so your site lives at your
+          clickfolio.me handle for now. If you'd like a step-by-step walkthrough, read{" "}
+          <Link href="/blog/how-to-make-a-resume-website">how to make a resume website</Link>, or
+          check the guide built for <Link href="/for/student">students</Link>.
+        </p>
+      </section>
+
+      <section>
+        <h2>Make yourself easy to remember</h2>
+        <p>
+          You're competing for internships against classmates with nearly identical resumes. A
+          shareable site is a small move that makes you memorable — at career fairs, in
+          applications, and in the follow-up email after you meet a recruiter. It takes about a
+          minute and costs nothing.
+        </p>
+        <p>
+          <Link href="/" className="text-brand font-semibold">
+            Build your free student resume website now →
+          </Link>
+        </p>
+      </section>
+    </BlogPostLayout>
+  );
+}

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,6 +1,6 @@
-import { ChevronDown } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
+import { FaqAccordion } from "@/components/Faq";
 import { Footer } from "@/components/Footer";
 import { SiteHeader } from "@/components/SiteHeader";
 import { Button } from "@/components/ui/button";
@@ -85,23 +85,7 @@ export default function FAQPage() {
           </div>
 
           {/* Accordion */}
-          <div className="mt-12 space-y-3">
-            {FAQ_ITEMS.map((faq) => (
-              <details
-                key={faq.q}
-                className="group rounded-xl border border-border bg-card shadow-sm transition-colors open:border-border-strong"
-              >
-                <summary className="flex cursor-pointer list-none items-center justify-between gap-4 p-6 font-semibold text-foreground [&::-webkit-details-marker]:hidden">
-                  {faq.q}
-                  <ChevronDown
-                    className="size-5 shrink-0 text-muted-foreground transition-transform duration-200 group-open:rotate-180"
-                    aria-hidden="true"
-                  />
-                </summary>
-                <p className="px-6 pb-6 leading-relaxed text-muted-foreground">{faq.a}</p>
-              </details>
-            ))}
-          </div>
+          <FaqAccordion items={FAQ_ITEMS} className="mt-12" />
 
           {/* CTA */}
           <div className="mt-16 rounded-2xl border border-border bg-brand-subtle p-8 text-center sm:p-12">

--- a/app/for/consultant/page.tsx
+++ b/app/for/consultant/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { RoleFaqSection } from "@/components/Faq";
 import { Button } from "@/components/ui/button";
 import { siteConfig } from "@/lib/config/site";
 import {
@@ -30,6 +31,25 @@ export const metadata: Metadata = {
     description,
   },
 };
+
+const faqs = [
+  {
+    q: "My client work is under NDA. Can I still build a consultant portfolio website?",
+    a: 'Yes. Describe engagements by industry, scope, and outcome without naming the client, for example "led a cost program for a mid-market retailer." Granular privacy controls also let you hide contact details. You keep the credibility of results while respecting every confidentiality agreement.',
+  },
+  {
+    q: "Can I control what is public?",
+    a: "Yes. You can toggle visibility for your phone number and address, so you present a professional page publicly while keeping personal contact details private until you choose to share them. That control matters when your profile is also your business front.",
+  },
+  {
+    q: "Is clickfolio.me free?",
+    a: "Yes. Six templates are free with no time limit and no credit card. Four more unlock through referrals rather than payment. There is no paid tier. The project is open source under the MIT license, so independent consultants can rely on it long term.",
+  },
+  {
+    q: "What do I share with prospective clients?",
+    a: "You get a clickfolio.me/@handle link hosted on Cloudflare that loads fast and previews cleanly in email and on LinkedIn. Use it on proposals and in your signature so clients see your track record before the first call. Custom domains are on the roadmap.",
+  },
+];
 
 export default function ConsultantPage() {
   const webPageJsonLd = generateWebPageJsonLd(title, path, description);
@@ -84,16 +104,82 @@ export default function ConsultantPage() {
           <section className="mb-12">
             <h2 className="font-bold text-xl text-foreground mb-4">Your Digital Business Card</h2>
             <p className="text-muted-foreground mb-4">
-              A clickfolio.me @handle URL is the modern consultant's business card. Put it on
-              LinkedIn, in your email signature, and on proposals. Clients get a complete picture of
-              your expertise before the first call.
+              A clickfolio.me @handle URL is the modern consultant portfolio website and business
+              card in one. Put it on LinkedIn, in your email signature, and on proposals. Clients
+              get a complete picture of your expertise before the first call.
             </p>
             <p className="text-muted-foreground">
-              Rich Open Graph previews ensure your portfolio looks professional when shared. Every
-              detail — from typography to layout — is designed to project competence and
-              credibility.
+              Rich Open Graph previews keep your page looking professional when shared. Typography
+              and layout are tuned to project competence the moment someone clicks.
             </p>
           </section>
+
+          <section className="mb-12">
+            <h2 className="font-bold text-xl text-foreground mb-4">
+              What to put on a consultant portfolio
+            </h2>
+            <p className="text-muted-foreground mb-4">
+              Clients buy outcomes and trust. A first scan takes about 7.4 seconds (The Ladders,
+              2018), so make your value obvious before anyone reads the detail.
+            </p>
+            <ul className="space-y-3 text-muted-foreground list-disc pl-5">
+              <li>
+                <strong>Engagements with results</strong> — the problem, your approach, and the
+                measurable outcome, framed by industry when names are confidential.
+              </li>
+              <li>
+                <strong>Areas of expertise</strong> — the two or three problems you solve best, so
+                clients self-qualify.
+              </li>
+              <li>
+                <strong>Credibility markers</strong> — certifications, years in the field, and the
+                kinds of organizations you serve.
+              </li>
+              <li>
+                <strong>A clear next step</strong> — how to reach you, on your terms.
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-bold text-xl text-foreground mb-4">
+              Templates that signal authority
+            </h2>
+            <ul className="space-y-3 text-muted-foreground list-disc pl-5">
+              <li>
+                <strong>Midnight</strong> — dark and minimal with serif headings and gold accents
+                for a high-end feel.
+              </li>
+              <li>
+                <strong>Minimalist Editorial</strong> — magazine-clean, putting your track record in
+                focus.
+              </li>
+              <li>
+                <strong>Bold Corporate</strong> — executive typography for a confident, polished
+                profile.
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-bold text-xl text-foreground mb-4">
+              "Most of my work is confidential"
+            </h2>
+            <p className="text-muted-foreground mb-4">
+              That is fine. You can describe each engagement by sector, scope, and result without
+              naming the client, and the privacy controls let you hide contact details until you are
+              ready. Your credibility comes through while every NDA stays intact.
+            </p>
+            <p className="text-muted-foreground">
+              Want the full setup walkthrough? Read{" "}
+              <a className="underline" href="/blog/personal-resume-website">
+                our guide to a personal resume website
+              </a>{" "}
+              before you publish.
+            </p>
+          </section>
+
+          <RoleFaqSection items={faqs} />
 
           <Button asChild size="lg">
             <a href="/">Create Your Consulting Portfolio</a>

--- a/app/for/designer/page.tsx
+++ b/app/for/designer/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { RoleFaqSection } from "@/components/Faq";
 import { Button } from "@/components/ui/button";
 import { siteConfig } from "@/lib/config/site";
 import {
@@ -30,6 +31,25 @@ export const metadata: Metadata = {
     description,
   },
 };
+
+const faqs = [
+  {
+    q: "Do I need design skills to build a designer portfolio website?",
+    a: "No. You upload your existing PDF resume and the AI lays out a polished site for you. Every template is built by designers, so the typography, spacing, and hierarchy are already handled. You just pick the look you like and publish.",
+  },
+  {
+    q: "Can I show project work, not just a resume?",
+    a: "Yes. The AI pulls your projects from your resume and presents each one with its role, timeline, and description in a structured gallery. You can edit the details after import, so your strongest work leads and the rest supports it.",
+  },
+  {
+    q: "Is it actually free?",
+    a: "Yes. Six templates are free with no time limit and no credit card. Four more unlock through referrals rather than payment. There is no paid plan. The whole project is open source under the MIT license, so there is no catch.",
+  },
+  {
+    q: "What link do I share with studios and clients?",
+    a: "You get a clickfolio.me/@handle address hosted on real Cloudflare infrastructure. It loads fast and shows a rich preview when pasted into messages or social posts. Custom domains are on the roadmap, but your @handle link is permanent today.",
+  },
+];
 
 export default function DesignerPage() {
   const webPageJsonLd = generateWebPageJsonLd(title, path, description);
@@ -85,15 +105,80 @@ export default function DesignerPage() {
               From PDF to Published in 30 Seconds
             </h2>
             <p className="text-muted-foreground mb-4">
-              Drop your existing PDF resume — the one you already have. Our AI extracts your
-              experience, education, skills, and projects. In 30 seconds, you have a live portfolio
-              you can share with studios, agencies, and clients.
+              Drop the PDF resume you already have. The AI extracts your experience, education,
+              skills, and projects. In about 30 seconds you have a live designer portfolio website
+              you can send to studios, agencies, and clients.
             </p>
             <p className="text-muted-foreground">
-              Not happy with the first template? Switch between 10 professionally designed themes
-              with one click. No design skills needed to make your work look great.
+              Not happy with the first look? Switch between 10 themes with one click. You never
+              touch a layout grid or a font menu unless you want to.
             </p>
           </section>
+
+          <section className="mb-12">
+            <h2 className="font-bold text-xl text-foreground mb-4">
+              What hiring designers look for
+            </h2>
+            <p className="text-muted-foreground mb-4">
+              Recruiters spend about 7.4 seconds on a first scan (The Ladders, 2018). For design
+              roles, that glance is about taste and clarity, so your page has to look intentional in
+              the first second.
+            </p>
+            <ul className="space-y-3 text-muted-foreground list-disc pl-5">
+              <li>
+                <strong>A clear point of view</strong> — a few strong projects beat a wall of
+                thumbnails. Lead with the work you want more of.
+              </li>
+              <li>
+                <strong>Context per project</strong> — your role, the problem, and the outcome.
+                Designers get hired on thinking, not just pixels.
+              </li>
+              <li>
+                <strong>Craft in the details</strong> — consistent type, spacing, and alignment. A
+                tidy page signals a tidy designer.
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-bold text-xl text-foreground mb-4">
+              Templates with a designer's eye
+            </h2>
+            <ul className="space-y-3 text-muted-foreground list-disc pl-5">
+              <li>
+                <strong>DesignFolio</strong> — digital brutalism with Swiss typography and acid lime
+                accents. Bold and memorable.
+              </li>
+              <li>
+                <strong>Spotlight</strong> — warm and animated, with room for each project to
+                breathe.
+              </li>
+              <li>
+                <strong>Glass Morphic</strong> — soft, layered, and modern when you want a lighter
+                feel.
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-bold text-xl text-foreground mb-4">
+              "Shouldn't I hand-build my own site?"
+            </h2>
+            <p className="text-muted-foreground mb-4">
+              You can, and some designers do. But a hand-built site is a project that competes with
+              your actual work. clickfolio.me gives you a clean, fast page today, so your time goes
+              into the portfolio pieces instead of CSS.
+            </p>
+            <p className="text-muted-foreground">
+              Looking for inspiration first? Browse{" "}
+              <a className="underline" href="/blog/resume-website-examples">
+                resume website examples
+              </a>{" "}
+              to see layouts you can recreate in minutes.
+            </p>
+          </section>
+
+          <RoleFaqSection items={faqs} />
 
           <Button asChild size="lg">
             <a href="/">Create Your Free Design Portfolio</a>

--- a/app/for/marketer/page.tsx
+++ b/app/for/marketer/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { RoleFaqSection } from "@/components/Faq";
 import { Button } from "@/components/ui/button";
 import { siteConfig } from "@/lib/config/site";
 import {
@@ -30,6 +31,25 @@ export const metadata: Metadata = {
     description,
   },
 };
+
+const faqs = [
+  {
+    q: "I'm early in my marketing career. Is this worth it?",
+    a: "Yes. A marketing portfolio website shows initiative even with one or two campaigns. You can feature class projects, internships, freelance work, or a side channel you grew. A clean page with real numbers beats a long resume of responsibilities every time.",
+  },
+  {
+    q: "Can I highlight campaign metrics and results?",
+    a: "Yes. The AI pulls your growth numbers, campaign results, and brand names from your resume and puts them front and center. Marketers get hired on outcomes, so the templates are built to make your metrics the first thing a recruiter sees.",
+  },
+  {
+    q: "Is clickfolio.me free?",
+    a: "Yes. Six templates are free forever with no credit card and no trial. Four more unlock through referrals, not payment. There is no paid tier. The project is open source under the MIT license, so you can even see how it works.",
+  },
+  {
+    q: "Will my portfolio look good when I share the link?",
+    a: "Yes. Every clickfolio.me/@handle page generates a rich Open Graph preview, so it unfurls cleanly on LinkedIn, Slack, and email. You get a permanent link to put in your bio and signature. Custom domains are planned for the future.",
+  },
+];
 
 export default function MarketerPage() {
   const webPageJsonLd = generateWebPageJsonLd(title, path, description);
@@ -84,15 +104,85 @@ export default function MarketerPage() {
           <section className="mb-12">
             <h2 className="font-bold text-xl text-foreground mb-4">Your Portfolio, Your Brand</h2>
             <p className="text-muted-foreground mb-4">
-              Every marketer knows the power of a strong landing page. Your clickfolio.me portfolio
-              is your personal landing page — a permanent @handle URL you can put on LinkedIn, in
-              your email signature, and on your business cards.
+              Every marketer knows the power of a strong landing page. Your marketing portfolio
+              website is your personal landing page: a permanent @handle URL you can put on
+              LinkedIn, in your email signature, and on your business cards.
             </p>
             <p className="text-muted-foreground">
-              Rich Open Graph previews mean your portfolio looks great when shared on social media,
-              Slack, or anywhere links are unfurled. Your personal brand, amplified.
+              Rich Open Graph previews mean your page looks sharp when shared on social, in Slack,
+              or anywhere links unfurl. Your personal brand gets the same polish you give your
+              clients.
             </p>
           </section>
+
+          <section className="mb-12">
+            <h2 className="font-bold text-xl text-foreground mb-4">
+              What to feature on a marketing portfolio
+            </h2>
+            <p className="text-muted-foreground mb-4">
+              Recruiters spend about 7.4 seconds on a first scan (The Ladders, 2018). For marketing
+              roles, they are hunting for proof you move numbers, so put the results where they land
+              first.
+            </p>
+            <ul className="space-y-3 text-muted-foreground list-disc pl-5">
+              <li>
+                <strong>Campaign outcomes</strong> — the goal, what you did, and the result. "Grew
+                signups 38% in a quarter" beats "ran the email program."
+              </li>
+              <li>
+                <strong>Channels and tools</strong> — paid, SEO, lifecycle, content, and the
+                platforms you actually run.
+              </li>
+              <li>
+                <strong>Brands and scope</strong> — the companies you supported and the audience
+                size you reached.
+              </li>
+              <li>
+                <strong>Samples worth clicking</strong> — a landing page, a post, or a deck that
+                shows your taste.
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-bold text-xl text-foreground mb-4">
+              Templates that command attention
+            </h2>
+            <ul className="space-y-3 text-muted-foreground list-disc pl-5">
+              <li>
+                <strong>Bold Corporate</strong> — executive typography and numbered sections that
+                make your wins hard to skim past.
+              </li>
+              <li>
+                <strong>Neo Brutalist</strong> — high-contrast and confident, with personality that
+                pops in a link preview.
+              </li>
+              <li>
+                <strong>Bento Grid</strong> — a mosaic that turns campaigns and metrics into clean,
+                scannable cards.
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-bold text-xl text-foreground mb-4">
+              "I don't have a huge campaign list yet"
+            </h2>
+            <p className="text-muted-foreground mb-4">
+              You do not need one. A focused page with two or three real results reads stronger than
+              a padded resume. Show the work you are proud of, frame the outcome, and let the page
+              do the convincing.
+            </p>
+            <p className="text-muted-foreground">
+              Want a walkthrough before you start? Read{" "}
+              <a className="underline" href="/blog/how-to-make-a-resume-website">
+                how to make a resume website
+              </a>{" "}
+              for a step-by-step guide.
+            </p>
+          </section>
+
+          <RoleFaqSection items={faqs} />
 
           <Button asChild size="lg">
             <a href="/">Create Your Free Marketing Portfolio</a>

--- a/app/for/product-manager/page.tsx
+++ b/app/for/product-manager/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { RoleFaqSection } from "@/components/Faq";
 import { Button } from "@/components/ui/button";
 import { siteConfig } from "@/lib/config/site";
 import {
@@ -30,6 +31,25 @@ export const metadata: Metadata = {
     description,
   },
 };
+
+const faqs = [
+  {
+    q: "My product work is confidential. Can I still build a product manager portfolio website?",
+    a: 'Yes. Frame launches by impact and context without exposing roadmaps under NDA, for example "led a checkout redesign that lifted conversion 12%." You control what is visible, so you keep the credibility of real outcomes while honoring every confidentiality agreement.',
+  },
+  {
+    q: "Can I show metrics and outcomes, not just titles?",
+    a: "Yes. The AI pulls your launches, metrics, and cross-functional wins from your resume, and the templates put numbers up front. PMs get hired on impact, so the page is built to lead with the ROI you delivered instead of a list of responsibilities.",
+  },
+  {
+    q: "Is it free?",
+    a: "Yes. Six templates are free with no credit card and no trial. Four more unlock through referrals, not payment. There is no paid tier. The project is open source under the MIT license, so there is nothing to buy and no upsell waiting later.",
+  },
+  {
+    q: "What link do I put on my resume and LinkedIn?",
+    a: "You get a clickfolio.me/@handle address hosted on Cloudflare. It loads fast and previews cleanly when shared on LinkedIn, Slack, or email. Use it on your resume and in your signature. Custom bring-your-own domains are on the roadmap for the future.",
+  },
+];
 
 export default function ProductManagerPage() {
   const webPageJsonLd = generateWebPageJsonLd(title, path, description);
@@ -85,16 +105,81 @@ export default function ProductManagerPage() {
           <section className="mb-12">
             <h2 className="font-bold text-xl text-foreground mb-4">Your Portfolio Is a Product</h2>
             <p className="text-muted-foreground mb-4">
-              As a PM, you know that presentation matters. Your clickfolio.me portfolio is the
-              product that sells you — fast-loading, well-structured, and designed to convert
-              recruiters and hiring managers into interview requests.
+              As a PM, you know presentation matters. Your product manager portfolio website is the
+              product that sells you: fast-loading, well-structured, and built to turn recruiters
+              and hiring managers into interview requests.
             </p>
             <p className="text-muted-foreground">
-              Switch between 10 templates to find the one that best represents your style. Every
-              template is mobile-responsive and optimized for rich link previews on LinkedIn, Slack,
-              and email.
+              Switch between 10 templates to find the one that fits your style. Each is
+              mobile-responsive and tuned for rich link previews on LinkedIn, Slack, and email.
             </p>
           </section>
+
+          <section className="mb-12">
+            <h2 className="font-bold text-xl text-foreground mb-4">
+              What hiring managers look for in a PM
+            </h2>
+            <p className="text-muted-foreground mb-4">
+              A first scan takes about 7.4 seconds (The Ladders, 2018). For product roles, reviewers
+              want evidence of judgment and impact, so make your strongest launch the first thing
+              they see.
+            </p>
+            <ul className="space-y-3 text-muted-foreground list-disc pl-5">
+              <li>
+                <strong>Outcomes over activity</strong> — the metric you moved and the decision
+                behind it, not a list of meetings run.
+              </li>
+              <li>
+                <strong>Product stories</strong> — the problem, your bet, the trade-offs, and the
+                result. Show how you think.
+              </li>
+              <li>
+                <strong>Cross-functional scope</strong> — who you led, the teams you aligned, and
+                the size of the surface you owned.
+              </li>
+              <li>
+                <strong>Customer and market sense</strong> — the insight that drove the work.
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-bold text-xl text-foreground mb-4">Templates built for impact</h2>
+            <ul className="space-y-3 text-muted-foreground list-disc pl-5">
+              <li>
+                <strong>Bento Grid</strong> — a mosaic that turns launches and metrics into clean,
+                scannable cards.
+              </li>
+              <li>
+                <strong>Spotlight</strong> — warm and animated, giving each initiative room to tell
+                its story.
+              </li>
+              <li>
+                <strong>Bold Corporate</strong> — executive type that makes results impossible to
+                skim past.
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-bold text-xl text-foreground mb-4">
+              "My roadmaps are confidential"
+            </h2>
+            <p className="text-muted-foreground mb-4">
+              You do not need to expose anything under NDA. Describe each launch by its impact and
+              context, keep specifics general, and use the privacy controls to manage what is
+              visible. The result still proves you ship, without breaking a single agreement.
+            </p>
+            <p className="text-muted-foreground">
+              Want a deeper how-to first? Read{" "}
+              <a className="underline" href="/blog/product-manager-portfolio-website">
+                our guide to a product manager portfolio website
+              </a>{" "}
+              for examples and structure.
+            </p>
+          </section>
+
+          <RoleFaqSection items={faqs} />
 
           <Button asChild size="lg">
             <a href="/">Create Your Free PM Portfolio</a>

--- a/app/for/software-engineer/page.tsx
+++ b/app/for/software-engineer/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { RoleFaqSection } from "@/components/Faq";
 import { Button } from "@/components/ui/button";
 import { siteConfig } from "@/lib/config/site";
 import {
@@ -30,6 +31,25 @@ export const metadata: Metadata = {
     description,
   },
 };
+
+const faqs = [
+  {
+    q: "Is clickfolio.me really free for software engineers?",
+    a: "Yes. You can upload your resume, get a hosted developer portfolio, and use 6 templates with no payment ever. Four more templates unlock through referrals, not money. There is no paid tier and no credit card. The project is open source under the MIT license.",
+  },
+  {
+    q: "Can I link my GitHub and LinkedIn?",
+    a: "Yes. Add your GitHub, LinkedIn, and other profile links directly to your portfolio. Recruiters get one-click access to your repositories and professional network, so your code and contribution history back up the claims on your resume without extra effort.",
+  },
+  {
+    q: "Will the AI read a technical resume correctly?",
+    a: "It is built for technical resumes. The parser identifies programming languages, frameworks, databases, and cloud platforms, and separates work experience from side projects. You can review and adjust everything after the import, so nothing important gets mislabeled.",
+  },
+  {
+    q: "Do I get a real URL I can share?",
+    a: "Every portfolio gets a clickfolio.me/@handle address hosted on Cloudflare. Put it on your resume, GitHub profile, or job applications. Custom bring-your-own domains are on the roadmap, but your @handle link is permanent and ready to share right away.",
+  },
+];
 
 export default function SoftwareEngineerPage() {
   const webPageJsonLd = generateWebPageJsonLd(title, path, description);
@@ -87,15 +107,88 @@ export default function SoftwareEngineerPage() {
             </h2>
             <p className="text-muted-foreground mb-4">
               clickfolio.me is open source (MIT), deployed on Cloudflare Workers, and built with
-              modern tools. No bloated page builders, no WYSIWYG clutter — just a clean,
-              fast-loading portfolio from your existing PDF resume.
+              modern tools. No bloated page builders, no WYSIWYG clutter, just a clean, fast-loading
+              software engineer portfolio from your existing PDF resume.
             </p>
             <p className="text-muted-foreground">
-              The AI parser understands technical resumes: it correctly identifies programming
-              languages, frameworks, databases, cloud platforms, and distinguishes between work
-              experience and side projects.
+              The AI parser understands technical resumes. It correctly identifies programming
+              languages, frameworks, databases, and cloud platforms, and tells your work experience
+              apart from your side projects.
             </p>
           </section>
+
+          <section className="mb-12">
+            <h2 className="font-bold text-xl text-foreground mb-4">
+              What to put on a software engineer portfolio
+            </h2>
+            <p className="text-muted-foreground mb-4">
+              Recruiters spend about 7.4 seconds on a first resume scan (The Ladders, 2018), so your
+              page has to answer their questions fast. Lead with the work that shows judgment, not
+              just a list of tools.
+            </p>
+            <ul className="space-y-3 text-muted-foreground list-disc pl-5">
+              <li>
+                <strong>Shipped projects with outcomes</strong> — what you built, the stack, and the
+                result. A link to a live demo or repo beats a paragraph of description.
+              </li>
+              <li>
+                <strong>Your core stack</strong> — the 5 to 8 languages and frameworks you actually
+                reach for, separated from things you have only touched once.
+              </li>
+              <li>
+                <strong>Scope and impact</strong> — team size, traffic served, latency cut, or money
+                saved. Numbers make a senior engineer look senior.
+              </li>
+              <li>
+                <strong>Links that prove it</strong> — GitHub, a personal site, or a package you
+                maintain. Evidence does more than adjectives.
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-bold text-xl text-foreground mb-4">
+              Which template fits a developer
+            </h2>
+            <p className="text-muted-foreground mb-4">
+              Pick the look that matches the roles you want. You can switch any time with one click,
+              so it costs nothing to try a few.
+            </p>
+            <ul className="space-y-3 text-muted-foreground list-disc pl-5">
+              <li>
+                <strong>DevTerminal</strong> — a dark, terminal-style theme with monospace type.
+                Signals "engineer" before anyone reads a word.
+              </li>
+              <li>
+                <strong>Classic ATS</strong> — clean and parser-friendly for when a recruiter wants
+                something plain to forward internally.
+              </li>
+              <li>
+                <strong>Minimalist Editorial</strong> — quiet, readable, and project-first when you
+                want the work to carry the page.
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-bold text-xl text-foreground mb-4">
+              "I already have a GitHub. Why a portfolio?"
+            </h2>
+            <p className="text-muted-foreground mb-4">
+              A GitHub profile shows code; it does not frame the story. A portfolio puts your best
+              work first, explains the impact in plain language, and gives non-technical recruiters
+              a way in. It takes one link instead of asking them to dig through repos.
+            </p>
+            <p className="text-muted-foreground">
+              Want examples and a step-by-step walkthrough? Read{" "}
+              <a className="underline" href="/blog/resume-website-examples">
+                our roundup of resume website examples
+              </a>{" "}
+              for ideas you can copy in minutes.
+            </p>
+          </section>
+
+          <RoleFaqSection items={faqs} />
 
           <Button asChild size="lg">
             <a href="/">Create Your Free Resume Website</a>

--- a/app/for/student/page.tsx
+++ b/app/for/student/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { RoleFaqSection } from "@/components/Faq";
 import { Button } from "@/components/ui/button";
 import { siteConfig } from "@/lib/config/site";
 import {
@@ -30,6 +31,25 @@ export const metadata: Metadata = {
     description,
   },
 };
+
+const faqs = [
+  {
+    q: "I have no work experience. Can I still build a student resume website?",
+    a: "Yes. The layout surfaces your education, coursework, academic projects, and clubs, so a thin work history is not a problem. Recruiters for internships expect students to lead with projects and skills. A live site shows initiative that a plain PDF cannot.",
+  },
+  {
+    q: "Is it free for students?",
+    a: "Yes, and there is no trial clock. Six templates are free forever with no credit card. Four more unlock when friends sign up through your referral, not by paying. The project is open source under the MIT license, so it stays free.",
+  },
+  {
+    q: "How long does it take to make one?",
+    a: "About 30 seconds. You upload the PDF resume you already have and the AI builds the site, pulling out your education, projects, and skills. You can review and tweak everything, then share your clickfolio.me/@handle link right away.",
+  },
+  {
+    q: "Where can I use my portfolio link?",
+    a: "Put your @handle URL on internship applications, your LinkedIn, your email signature, and the resume you hand out at career fairs. It loads fast and previews cleanly when shared, which helps you stand out from classmates who only send a PDF.",
+  },
+];
 
 export default function StudentPage() {
   const webPageJsonLd = generateWebPageJsonLd(title, path, description);
@@ -86,16 +106,82 @@ export default function StudentPage() {
           <section className="mb-12">
             <h2 className="font-bold text-xl text-foreground mb-4">Stand Out from the Stack</h2>
             <p className="text-muted-foreground mb-4">
-              Most students apply with a PDF. You'll apply with a live website. Share your @handle
-              URL on internship applications, LinkedIn, and with recruiters at career fairs. It
-              shows initiative, technical skill, and attention to detail.
+              Most students apply with a PDF. You will apply with a live student resume website.
+              Share your @handle URL on internship applications, LinkedIn, and with recruiters at
+              career fairs. It shows initiative and attention to detail before you say a word.
             </p>
             <p className="text-muted-foreground">
-              No design skills? No problem. Drop your existing resume PDF and the AI handles
-              everything. Switch templates anytime as you discover your style. Your portfolio grows
-              with you.
+              No design skills? No problem. Drop your existing resume PDF and the AI handles the
+              rest. Switch templates any time as you find your style. Your portfolio grows with you.
             </p>
           </section>
+
+          <section className="mb-12">
+            <h2 className="font-bold text-xl text-foreground mb-4">
+              What to put on it when you're just starting
+            </h2>
+            <p className="text-muted-foreground mb-4">
+              Recruiters spend about 7.4 seconds on a first scan (The Ladders, 2018), and for
+              entry-level roles they look for potential, not a long career. Give them clear signals
+              fast.
+            </p>
+            <ul className="space-y-3 text-muted-foreground list-disc pl-5">
+              <li>
+                <strong>Projects and coursework</strong> — a capstone, a class build, or a hackathon
+                entry. Show what you can do, not just what you studied.
+              </li>
+              <li>
+                <strong>Skills you actually use</strong> — tools, languages, and software you are
+                comfortable with.
+              </li>
+              <li>
+                <strong>Activities and leadership</strong> — clubs, teams, and volunteer roles that
+                show you follow through.
+              </li>
+              <li>
+                <strong>Education details</strong> — major, expected graduation, and standout
+                results worth highlighting.
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-bold text-xl text-foreground mb-4">Templates that fit a student</h2>
+            <ul className="space-y-3 text-muted-foreground list-disc pl-5">
+              <li>
+                <strong>Classic ATS</strong> — clean and parser-friendly for internship and
+                entry-level portals.
+              </li>
+              <li>
+                <strong>Bento Grid</strong> — a mosaic that turns coursework, projects, and clubs
+                into impressive cards.
+              </li>
+              <li>
+                <strong>Minimalist Editorial</strong> — simple and readable when you want the work
+                to speak.
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="font-bold text-xl text-foreground mb-4">
+              "What if I have nothing to show yet?"
+            </h2>
+            <p className="text-muted-foreground mb-4">
+              Everyone starts there. One class project, one internship, or one club role is enough
+              to fill a page that looks intentional. The point is to look organized and motivated,
+              and a clean site does that on its own.
+            </p>
+            <p className="text-muted-foreground">
+              New to all of this? Start with{" "}
+              <a className="underline" href="/blog/student-resume-website">
+                our guide to building a student resume website
+              </a>{" "}
+              for a simple walkthrough.
+            </p>
+          </section>
+
+          <RoleFaqSection items={faqs} />
 
           <Button asChild size="lg">
             <a href="/">Build Your Free Student Portfolio</a>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,19 +13,22 @@ import { WhatYouGetSection } from "@/components/home/WhatYouGetSection";
 import { ReferralCapture } from "@/components/ReferralCapture";
 import { SiteHeader } from "@/components/SiteHeader";
 import { Badge } from "@/components/ui/badge";
+import { PROFESSIONS } from "@/lib/config/professions";
 import { siteConfig } from "@/lib/config/site";
 import { generateFAQJsonLd, generateHomepageJsonLd, serializeJsonLd } from "@/lib/seo/json-ld";
 import { DEMO_PROFILES } from "@/lib/templates/demo-data";
 
 export const revalidate = 3600;
 
-const pageTitle = `${siteConfig.fullName} — ${siteConfig.tagline}`;
+const pageTitle = `Free Resume Website Builder — ${siteConfig.fullName}`;
 const pageDescription =
-  "Drop your PDF resume and get a shareable website in seconds. Free resume builder with 10 templates, @handle URLs, and privacy controls. No signup.";
+  "Free resume website builder. Turn your PDF resume or LinkedIn into a personal portfolio website in 30 seconds — 10 templates, custom @handle URL, privacy controls. No signup to start.";
 
 /** SEO metadata for the marketing homepage. */
 export const metadata: Metadata = {
-  title: siteConfig.tagline,
+  title: {
+    absolute: `Free Resume Website Builder — Turn Your PDF Into a Site | ${siteConfig.fullName}`,
+  },
   description: pageDescription,
   alternates: { canonical: siteConfig.url },
   openGraph: {
@@ -92,7 +95,10 @@ export default function Home() {
                     Your resume is already a <span className="text-brand">website</span>.
                   </h1>
                   <p className="mt-5 max-w-lg text-lg text-muted-foreground">
-                    Drop your PDF and get a shareable portfolio link in about{" "}
+                    clickfolio.me is a free{" "}
+                    <strong className="font-medium text-foreground">resume website builder</strong>{" "}
+                    that turns your PDF or LinkedIn into a personal portfolio site. Drop your resume
+                    and get a shareable link in about{" "}
                     <span className="font-medium text-foreground">30 seconds</span>.
                   </p>
 
@@ -238,6 +244,29 @@ export default function Home() {
                     <h3 className="mt-4 font-semibold">{item.title}</h3>
                     <p className="mt-1.5 text-sm text-muted-foreground">{item.desc}</p>
                   </div>
+                ))}
+              </div>
+            </section>
+
+            {/* Built for your role — internal links to profession landing pages */}
+            <section className="mt-20 lg:mt-28">
+              <h2 className="font-display text-2xl font-bold tracking-tight sm:text-3xl">
+                A resume website built for your role
+              </h2>
+              <p className="mt-2 max-w-2xl text-muted-foreground">
+                Whether you write code, design products, or pitch clients, clickfolio.me turns your
+                resume into a portfolio website that fits how your field gets hired.
+              </p>
+              <div className="mt-8 grid grid-cols-2 gap-3 sm:grid-cols-3">
+                {PROFESSIONS.map((role) => (
+                  <Link
+                    key={role.slug}
+                    href={`/for/${role.slug}`}
+                    className="group flex items-center justify-between gap-2 rounded-xl border border-border bg-card p-4 shadow-sm transition-colors hover:border-border-strong"
+                  >
+                    <span className="text-sm font-medium">{role.label}</span>
+                    <ArrowRight className="size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+                  </Link>
                 ))}
               </div>
             </section>

--- a/components/Faq.tsx
+++ b/components/Faq.tsx
@@ -1,0 +1,58 @@
+import { ChevronDown } from "lucide-react";
+import { generateFAQPageJsonLd, serializeJsonLd } from "@/lib/seo/json-ld";
+import { cn } from "@/lib/utils/cn";
+
+export interface FaqItem {
+  q: string;
+  a: string;
+}
+
+/**
+ * Collapsible FAQ accordion (native <details>). Shared by the full FAQ page and
+ * blog post layout. Callers supply their own surrounding section + heading.
+ */
+export function FaqAccordion({ items, className }: { items: FaqItem[]; className?: string }) {
+  return (
+    <div className={cn("space-y-3", className)}>
+      {items.map((faq) => (
+        <details
+          key={faq.q}
+          className="group rounded-xl border border-border bg-card shadow-sm transition-colors open:border-border-strong"
+        >
+          <summary className="flex cursor-pointer list-none items-center justify-between gap-4 p-6 font-semibold text-foreground [&::-webkit-details-marker]:hidden">
+            {faq.q}
+            <ChevronDown
+              className="size-5 shrink-0 text-muted-foreground transition-transform duration-200 group-open:rotate-180"
+              aria-hidden="true"
+            />
+          </summary>
+          <p className="px-6 pb-6 leading-relaxed text-muted-foreground">{faq.a}</p>
+        </details>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Static (always-expanded) FAQ section used by profession landing pages.
+ * Renders the visible Q&A list plus FAQPage JSON-LD in one place.
+ */
+export function RoleFaqSection({ items }: { items: FaqItem[] }) {
+  return (
+    <section className="mb-12">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(generateFAQPageJsonLd(items)) }}
+      />
+      <h2 className="font-bold text-xl text-foreground mb-4">Frequently asked questions</h2>
+      <div className="space-y-4">
+        {items.map((f) => (
+          <div key={f.q}>
+            <h3 className="font-semibold text-foreground mb-1">{f.q}</h3>
+            <p className="text-muted-foreground">{f.a}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/blog/BlogPostLayout.tsx
+++ b/components/blog/BlogPostLayout.tsx
@@ -1,12 +1,14 @@
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
+import { FaqAccordion } from "@/components/Faq";
 import { Footer } from "@/components/Footer";
 import { Logo } from "@/components/Logo";
 import { Badge } from "@/components/ui/badge";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import type { BlogPostMeta } from "@/lib/blog/posts";
+import { authorPersona } from "@/lib/config/author";
 import { siteConfig } from "@/lib/config/site";
-import { serializeJsonLd } from "@/lib/seo/json-ld";
+import { generateFAQPageJsonLd, serializeJsonLd } from "@/lib/seo/json-ld";
 
 interface BlogPostLayoutProps {
   post: BlogPostMeta;
@@ -22,13 +24,14 @@ function generateArticleJsonLd(post: BlogPostMeta): Record<string, unknown> {
     headline: post.title,
     description: post.description,
     datePublished: post.date,
-    dateModified: post.date,
+    dateModified: post.dateModified ?? post.date,
     url: `${siteConfig.url}/blog/${post.slug}`,
     keywords: post.keywords?.join(", "),
     author: {
-      "@type": "Organization",
-      name: siteConfig.fullName,
-      url: siteConfig.url,
+      "@type": "Person",
+      name: authorPersona.name,
+      description: authorPersona.bio,
+      url: authorPersona.url,
     },
     publisher: {
       "@type": "Organization",
@@ -83,6 +86,9 @@ function generateBlogBreadcrumbJsonLd(post: BlogPostMeta): Record<string, unknow
 export function BlogPostLayout({ post, children, relatedPosts }: BlogPostLayoutProps) {
   const articleJsonLd = generateArticleJsonLd(post);
   const breadcrumbJsonLd = generateBlogBreadcrumbJsonLd(post);
+  const faqJsonLd = post.faq && post.faq.length > 0 ? generateFAQPageJsonLd(post.faq) : null;
+  const updatedDate = post.dateModified ?? post.date;
+  const wasUpdated = Boolean(post.dateModified && post.dateModified !== post.date);
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
@@ -94,6 +100,12 @@ export function BlogPostLayout({ post, children, relatedPosts }: BlogPostLayoutP
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }}
       />
+      {faqJsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(faqJsonLd) }}
+        />
+      )}
       <header className="sticky top-0 z-50 border-b border-border bg-background/90 backdrop-blur-sm">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
           <Link
@@ -129,9 +141,12 @@ export function BlogPostLayout({ post, children, relatedPosts }: BlogPostLayoutP
             <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-foreground mb-4 leading-tight tracking-tight">
               {post.title}
             </h1>
-            <div className="flex items-center gap-4 text-muted-foreground text-sm">
-              <time dateTime={post.date} suppressHydrationWarning>
-                {new Date(post.date).toLocaleDateString("en-US", {
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-muted-foreground text-sm">
+              <span className="font-medium text-foreground">{authorPersona.name}</span>
+              <span aria-hidden="true">·</span>
+              <time dateTime={updatedDate} suppressHydrationWarning>
+                {wasUpdated ? "Updated " : ""}
+                {new Date(updatedDate).toLocaleDateString("en-US", {
                   year: "numeric",
                   month: "long",
                   day: "numeric",
@@ -162,6 +177,24 @@ export function BlogPostLayout({ post, children, relatedPosts }: BlogPostLayoutP
               {children}
             </div>
           </div>
+
+          {post.faq && post.faq.length > 0 && (
+            <section className="mt-12 border-t border-border pt-8">
+              <h2 className="text-2xl font-semibold text-foreground mb-6">
+                Frequently asked questions
+              </h2>
+              <FaqAccordion items={post.faq} />
+            </section>
+          )}
+
+          <section className="mt-12 border-t border-border pt-8">
+            <div className="rounded-xl border border-border bg-surface-2 p-6">
+              <p className="text-sm font-semibold text-foreground">{authorPersona.name}</p>
+              <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                {authorPersona.bio}
+              </p>
+            </div>
+          </section>
 
           <div className="mt-8 text-center">
             <Link

--- a/components/home/UsageStats.tsx
+++ b/components/home/UsageStats.tsx
@@ -1,9 +1,9 @@
 export function UsageStats() {
   const stats = [
-    { stat: "95%+", label: "Accuracy", desc: "AI parsing accuracy across 10,000+ resumes" },
     { stat: "~30s", label: "Setup", desc: "Average time from upload to live portfolio" },
     { stat: "10", label: "Templates", desc: "Professionally designed, mobile-responsive themes" },
-    { stat: "Free", label: "Forever", desc: "No trials, no credit card, no time limits" },
+    { stat: "$0", label: "Forever", desc: "No trials, no credit card, no time limits" },
+    { stat: "MIT", label: "Open source", desc: "Transparent code you can inspect on GitHub" },
   ];
 
   return (

--- a/lib/blog/posts.ts
+++ b/lib/blog/posts.ts
@@ -1,14 +1,306 @@
+export interface BlogPostFaq {
+  q: string;
+  a: string;
+}
+
 export interface BlogPostMeta {
   slug: string;
   title: string;
   description: string;
+  /** ISO date the post was first published. */
   date: string;
+  /** ISO date the post was last updated. Falls back to `date` when absent. */
+  dateModified?: string;
   readTime: string;
   category: string;
   keywords: string[];
+  /**
+   * Optional FAQ items rendered as a visible section + FAQPage schema.
+   * Boosts rich-result eligibility and AI answer extraction.
+   */
+  faq?: BlogPostFaq[];
 }
 
 export const BLOG_POSTS: BlogPostMeta[] = [
+  {
+    slug: "read-cv-alternatives",
+    title: "Read.cv Alternatives: Where to Move Your Profile After the Shutdown (2026)",
+    description:
+      "Read.cv was acquired by Perplexity and wound down in 2025. Here's where to move your professional profile and resume website now — with free options.",
+    date: "2026-06-09",
+    dateModified: "2026-06-19",
+    readTime: "8 min read",
+    category: "Comparison",
+    keywords: [
+      "read.cv alternative",
+      "read cv shut down",
+      "read.cv replacement",
+      "resume website alternative",
+      "personal site after read.cv",
+    ],
+    faq: [
+      {
+        q: "Why did Read.cv shut down?",
+        a: "Read.cv was acquired by AI search company Perplexity in January 2025 and began winding down. Users could export their data until May 16, 2025, and the profile and Sites features were discontinued.",
+      },
+      {
+        q: "What is the best free Read.cv alternative?",
+        a: "If you mainly used Read.cv to host a clean professional profile, a resume website builder like clickfolio.me is the closest free replacement — upload your resume PDF and get a hosted clickfolio.me/@handle site in about 30 seconds.",
+      },
+      {
+        q: "How do I move my Read.cv profile to a new site?",
+        a: "Export or recreate your resume as a PDF, then upload it to a resume website builder. clickfolio.me's AI reads your experience, education, and skills and rebuilds them as an editable hosted page.",
+      },
+    ],
+  },
+  {
+    slug: "resume-website-examples",
+    title: "12 Resume Website Examples to Inspire Your Own (2026)",
+    description:
+      "Real resume website examples across minimal, creative, and developer styles — what makes each one work, and how to build your own for free.",
+    date: "2026-06-02",
+    dateModified: "2026-06-19",
+    readTime: "9 min read",
+    category: "Inspiration",
+    keywords: [
+      "resume website examples",
+      "resume websites examples",
+      "cool cv websites",
+      "personal website examples",
+      "portfolio website examples",
+    ],
+    faq: [
+      {
+        q: "What does a good resume website look like?",
+        a: "A good resume website loads fast, works on mobile, leads with your name and current role, and puts your strongest experience and projects above the fold. It uses one clear layout, readable type, and a single obvious way to contact you.",
+      },
+      {
+        q: "What should every resume website include?",
+        a: "Your name and headline, a short summary, work experience with outcomes, skills, education, links to your work or profiles, and a contact method. Keep it scannable — recruiters skim before they read.",
+      },
+      {
+        q: "How do I make a resume website like these examples for free?",
+        a: "Upload your PDF resume to a free builder like clickfolio.me. It parses your details and applies a professional template, so you get an example-quality site without designing one from scratch.",
+      },
+    ],
+  },
+  {
+    slug: "personal-resume-website",
+    title: "What Is a Personal Resume Website? (And Why You Need One in 2026)",
+    description:
+      "A personal resume website is a site you own that presents your career better than a PDF or LinkedIn. Here's what it is, why it helps, and how to make one free.",
+    date: "2026-05-26",
+    dateModified: "2026-06-19",
+    readTime: "7 min read",
+    category: "Guide",
+    keywords: [
+      "personal resume website",
+      "personal resume site",
+      "personal website resume",
+      "resume website",
+      "own resume website",
+    ],
+    faq: [
+      {
+        q: "What is a personal resume website?",
+        a: "A personal resume website is a web page you own that presents your professional background — experience, skills, projects, and contact info — at your own URL. Unlike a PDF, it's always current and shareable with a single link.",
+      },
+      {
+        q: "Is a personal resume site worth it?",
+        a: "Yes for most job seekers. It gives you a professional link for applications, email signatures, and your LinkedIn profile, helps you rank in Google for your own name, and lets you track who's viewing your background.",
+      },
+      {
+        q: "How is a personal resume website different from LinkedIn?",
+        a: "LinkedIn is rented space with a fixed layout shared by everyone. A personal resume website is yours — you control the design, the URL, the content, and the analytics, and no algorithm decides who sees it.",
+      },
+    ],
+  },
+  {
+    slug: "how-to-make-a-resume-website",
+    title: "How to Make a Resume Website: A Step-by-Step Guide (2026)",
+    description:
+      "Build a resume website in minutes — no coding. A step-by-step guide covering content, templates, custom URLs, and publishing your PDF resume as a live site.",
+    date: "2026-05-19",
+    dateModified: "2026-06-19",
+    readTime: "8 min read",
+    category: "How-To",
+    keywords: [
+      "how to make a resume website",
+      "build a resume website",
+      "create a resume website",
+      "make a resume website free",
+      "resume website tutorial",
+    ],
+    faq: [
+      {
+        q: "How do I make a resume website step by step?",
+        a: "Prepare your resume content, choose a builder or template, add your experience and projects, pick a clean URL, then publish. With an AI builder like clickfolio.me you can skip most steps: upload your PDF and it builds the page for you.",
+      },
+      {
+        q: "Do I need to know how to code to build a resume website?",
+        a: "No. Resume website builders and resume-to-site converters let you publish a professional site with no code. Coding your own is an option for developers who want full control, but it's not required.",
+      },
+      {
+        q: "Can I turn my existing resume PDF into a website?",
+        a: "Yes. Tools like clickfolio.me read your PDF resume with AI and rebuild it as an editable hosted website in about 30 seconds, so you don't have to retype anything.",
+      },
+    ],
+  },
+  {
+    slug: "cv-website-builder",
+    title: "CV Website Builder: Turn Your CV Into a Site in 2026",
+    description:
+      "What a CV website builder does, the features that matter, and how to turn your CV into a fast, hosted website — free, with no coding.",
+    date: "2026-05-12",
+    dateModified: "2026-06-19",
+    readTime: "7 min read",
+    category: "Guide",
+    keywords: [
+      "cv website builder",
+      "cv website",
+      "online cv builder",
+      "cv to website",
+      "free cv website",
+    ],
+    faq: [
+      {
+        q: "What is the best CV website builder?",
+        a: "The best CV website builder depends on whether you want speed or full design control. For most people, an AI converter like clickfolio.me wins on speed — it turns a CV PDF into a hosted site free in about 30 seconds.",
+      },
+      {
+        q: "Are there free CV website builders?",
+        a: "Yes. clickfolio.me is free forever for its core features, including hosting and a custom @handle URL. General builders like Carrd are cheap but charge for custom domains and don't import your CV automatically.",
+      },
+      {
+        q: "Can a builder turn my CV into a site automatically?",
+        a: "Some can. AI-powered tools read your CV's text and structure, then map it into a template — so your experience, skills, and education appear on the page without manual data entry.",
+      },
+    ],
+  },
+  {
+    slug: "resume-hosting",
+    title: "Resume Hosting: How to Put Your Resume Online With a Shareable Link (2026)",
+    description:
+      "Stop emailing PDF attachments. Learn how to host your resume online, get one shareable link, track views, and control privacy — free.",
+    date: "2026-05-05",
+    dateModified: "2026-06-19",
+    readTime: "7 min read",
+    category: "Guide",
+    keywords: [
+      "resume hosting",
+      "resume hosting site",
+      "host resume online",
+      "shareable resume link",
+      "resume online link",
+    ],
+    faq: [
+      {
+        q: "Where can I host my resume online for free?",
+        a: "clickfolio.me hosts your resume as a live website free, with a clickfolio.me/@handle link you can share anywhere. It's faster and more professional than uploading a PDF to a file host.",
+      },
+      {
+        q: "Is it better to send a PDF or a resume link?",
+        a: "Send both. Use a PDF when an application requires a file or ATS upload, and share a hosted resume link in emails, your LinkedIn, and your signature — the link is always current and can track views.",
+      },
+      {
+        q: "Can I track who views my hosted resume?",
+        a: "With a resume website like clickfolio.me, yes. Built-in analytics show how many people viewed your portfolio, unlike a static PDF attachment.",
+      },
+    ],
+  },
+  {
+    slug: "product-manager-portfolio-website",
+    title: "How to Build a Product Manager Portfolio Website (2026)",
+    description:
+      "A product manager portfolio proves how you think, not just what you shipped. Learn what to include, how to structure case studies, and how to publish one fast.",
+    date: "2026-04-29",
+    dateModified: "2026-06-19",
+    readTime: "9 min read",
+    category: "How-To",
+    keywords: [
+      "product manager portfolio website",
+      "product manager portfolio",
+      "pm portfolio",
+      "product manager website",
+      "product manager portfolio examples",
+    ],
+    faq: [
+      {
+        q: "Do product managers really need a portfolio?",
+        a: "Increasingly, yes. A PM portfolio shows your product thinking — how you found problems, prioritized, and drove outcomes — in a way a resume can't. It helps you stand out in a competitive hiring funnel.",
+      },
+      {
+        q: "What should a PM portfolio case study include?",
+        a: "The problem and who had it, the research and data behind your decisions, what you prioritized and why, what you shipped, and the measurable impact. Show the reasoning, not just the feature.",
+      },
+      {
+        q: "How do I build a PM portfolio if my work is under NDA?",
+        a: "Anonymize specifics — use ranges instead of exact numbers, describe the problem space generically, or use side projects and public product teardowns to demonstrate your process.",
+      },
+    ],
+  },
+  {
+    slug: "student-resume-website",
+    title: "How to Make a Student Resume Website With No Experience (2026)",
+    description:
+      "No job history? No problem. Learn how students can build a free resume website using projects, coursework, and activities — and stand out for internships.",
+    date: "2026-04-22",
+    dateModified: "2026-06-19",
+    readTime: "7 min read",
+    category: "How-To",
+    keywords: [
+      "student resume website",
+      "student portfolio website",
+      "resume website for students",
+      "student resume no experience",
+      "college resume website",
+    ],
+    faq: [
+      {
+        q: "Should a student have a resume website?",
+        a: "Yes — it's a low-effort way to stand out for internships and entry-level roles. A clean link on your applications and at career fairs signals initiative and makes you easy to remember.",
+      },
+      {
+        q: "What do I put on a student resume website with no work experience?",
+        a: "Lead with education, then class projects, coursework, clubs, volunteering, freelance or personal projects, and skills. Frame what you've built and learned, not just job titles.",
+      },
+      {
+        q: "How do I make a free student resume website?",
+        a: "Export your resume as a PDF and upload it to a free builder like clickfolio.me. It builds a hosted site with a shareable link in about 30 seconds — no coding or payment needed.",
+      },
+    ],
+  },
+  {
+    slug: "resume-website-vs-linkedin",
+    title: "Resume Website vs LinkedIn: Which Do You Need? (2026)",
+    description:
+      "Resume website or LinkedIn? They do different jobs. Compare control, design, SEO, and reach — and learn why the strongest move is using both together.",
+    date: "2026-04-16",
+    dateModified: "2026-06-19",
+    readTime: "7 min read",
+    category: "Comparison",
+    keywords: [
+      "resume website vs linkedin",
+      "personal website vs linkedin",
+      "linkedin alternative",
+      "resume site or linkedin",
+      "do i need a website if i have linkedin",
+    ],
+    faq: [
+      {
+        q: "Do I need a resume website if I have LinkedIn?",
+        a: "They serve different goals. LinkedIn gives you reach and recruiter discovery; a resume website gives you control, custom design, analytics, and a chance to rank in Google for your own name. Most professionals benefit from both.",
+      },
+      {
+        q: "Can my resume website rank above my LinkedIn for my name?",
+        a: "Often, yes. A personal site with your name in the domain, title, and headings can outrank a LinkedIn profile for your name over time, especially as it earns visits and links.",
+      },
+      {
+        q: "Which should recruiters get — my LinkedIn or my website?",
+        a: "Share both. Use LinkedIn to connect and be discovered, and send your resume website when someone wants the full, curated story of your work.",
+      },
+    ],
+  },
   {
     slug: "pdf-resume-to-website",
     title: "PDF Resume to Website Converter: The Complete Guide (2026)",
@@ -29,16 +321,31 @@ export const BLOG_POSTS: BlogPostMeta[] = [
     slug: "best-resume-website-builders",
     title: "Best Free Resume Website Builders Compared (2026)",
     description:
-      "We tested 8 resume-to-website tools. Here's how clickfolio.me, Magic Self, DockPage, and others stack up on features, pricing, and ease of use.",
+      "We compared the top resume website builders — clickfolio.me, Standard Resume, Carrd, Reactive Resume, and more — on templates, pricing, custom domains, and hosting.",
     date: "2026-04-25",
-    readTime: "10 min read",
+    dateModified: "2026-06-19",
+    readTime: "11 min read",
     category: "Comparison",
     keywords: [
+      "best resume website builder",
       "resume website builders",
       "free portfolio website",
       "resume to website tools",
-      "clickfolio vs alternatives",
       "online cv builder",
+    ],
+    faq: [
+      {
+        q: "What is the best free resume website builder?",
+        a: "For turning an existing resume into a hosted website fast, clickfolio.me is the best free option — it parses your PDF with AI and publishes a site with a custom @handle URL in about 30 seconds, free forever. Carrd is cheaper for hand-built one-page sites but doesn't import your resume.",
+      },
+      {
+        q: "Are resume website builders actually free?",
+        a: "Some are. clickfolio.me is free forever for hosting and core features. Many tools advertise 'free' but paywall custom URLs, branding removal, or custom domains — for example, Carrd requires a paid plan ($19/yr) for a custom domain.",
+      },
+      {
+        q: "Do I need a custom domain for my resume website?",
+        a: "Not to start. A clean hosted URL like clickfolio.me/@yourname is professional enough for applications and LinkedIn. A custom domain is a nice upgrade later, but it isn't required to look credible.",
+      },
     ],
   },
   {
@@ -75,10 +382,11 @@ export const BLOG_POSTS: BlogPostMeta[] = [
   },
   {
     slug: "linkedin-to-portfolio",
-    title: "LinkedIn to Portfolio Website: The Complete Guide",
+    title: "LinkedIn to Portfolio Website: The Complete Guide (2026)",
     description:
-      "LinkedIn is borrowed land. Learn how to turn your LinkedIn profile into a portfolio website you own, control, and can rank on Google.",
+      "LinkedIn is borrowed land. Learn how to turn your LinkedIn profile into a portfolio website you own, control, and can rank on Google — in about 30 seconds.",
     date: "2026-04-19",
+    dateModified: "2026-06-19",
     readTime: "7 min read",
     category: "How-To",
     keywords: [
@@ -87,6 +395,20 @@ export const BLOG_POSTS: BlogPostMeta[] = [
       "personal portfolio website",
       "linkedin alternative",
       "own your online presence",
+    ],
+    faq: [
+      {
+        q: "How do I turn my LinkedIn profile into a website?",
+        a: "Export your LinkedIn profile as a PDF (More → Save to PDF), then upload it to clickfolio.me. The AI reads your experience, education, and skills and rebuilds them as a hosted website at clickfolio.me/@yourname in about 30 seconds.",
+      },
+      {
+        q: "Is a portfolio website better than LinkedIn?",
+        a: "They do different jobs. LinkedIn is for networking and recruiter discovery; a portfolio website is land you own, with full control over design, URL, and analytics. The strongest approach is using both together.",
+      },
+      {
+        q: "Can a portfolio website rank on Google for my name?",
+        a: "Yes. A site with your name in the URL, title, and headings can rank for your name and build its own authority over time — something a LinkedIn profile on a shared domain can't do for you.",
+      },
     ],
   },
   {

--- a/lib/config/author.ts
+++ b/lib/config/author.ts
@@ -1,0 +1,23 @@
+/**
+ * Editorial author persona for blog content.
+ *
+ * This is a brand persona — a consistent byline that represents the clickfolio.me
+ * careers editorial desk, not a claim about a single private individual. It exists
+ * to give content a stable, accountable voice and to satisfy E-E-A-T / author
+ * attribution signals for search and AI engines. Keep the described expertise
+ * honest: it reflects what the team actually does (reviewing resumes, portfolios,
+ * and the resume-to-website workflow), with no fabricated employment history.
+ */
+
+import { siteConfig } from "@/lib/config/site";
+
+export const authorPersona = {
+  /** Byline name shown on posts. */
+  name: "The clickfolio Careers Desk",
+  /** Short role descriptor. */
+  role: "Careers & Portfolio Editorial Team",
+  /** Honest one-line bio (no fabricated credentials). */
+  bio: "The clickfolio Careers Desk is the editorial team behind clickfolio.me. We test resume and portfolio tools hands-on, study how recruiters read profiles, and write practical guides on turning a resume into a website that gets noticed.",
+  /** Canonical URL representing the author entity. */
+  url: `${siteConfig.url}/about`,
+} as const;

--- a/lib/config/author.ts
+++ b/lib/config/author.ts
@@ -14,8 +14,6 @@ import { siteConfig } from "@/lib/config/site";
 export const authorPersona = {
   /** Byline name shown on posts. */
   name: "The clickfolio Careers Desk",
-  /** Short role descriptor. */
-  role: "Careers & Portfolio Editorial Team",
   /** Honest one-line bio (no fabricated credentials). */
   bio: "The clickfolio Careers Desk is the editorial team behind clickfolio.me. We test resume and portfolio tools hands-on, study how recruiters read profiles, and write practical guides on turning a resume into a website that gets noticed.",
   /** Canonical URL representing the author entity. */

--- a/lib/config/professions.ts
+++ b/lib/config/professions.ts
@@ -1,0 +1,23 @@
+/**
+ * Canonical list of profession landing pages (`/for/<slug>`).
+ *
+ * Single source of truth consumed by the homepage "Built for your role" grid
+ * (needs display labels) and the sitemap builder (needs slugs + count). Add or
+ * remove a role here and both stay in sync.
+ */
+
+export interface Profession {
+  /** URL slug under /for/. Must match the directory in app/for/. */
+  slug: string;
+  /** Plural display label for navigation/grids. */
+  label: string;
+}
+
+export const PROFESSIONS: readonly Profession[] = [
+  { slug: "software-engineer", label: "Software Engineers" },
+  { slug: "designer", label: "Designers" },
+  { slug: "product-manager", label: "Product Managers" },
+  { slug: "marketer", label: "Marketers" },
+  { slug: "consultant", label: "Consultants" },
+  { slug: "student", label: "Students" },
+] as const;

--- a/lib/config/site.ts
+++ b/lib/config/site.ts
@@ -23,8 +23,6 @@ export const siteConfig = {
   url: `https://${domain}`,
   /** Brand alternate spellings for entity recognition (Knowledge Graph). */
   alternateNames: ["clickfolio", "click folio", "Clickfolio"],
-  /** Public source repository. */
-  githubUrl: "https://github.com/divkix/clickfolio.me",
   /**
    * Verified public profiles for the Organization `sameAs` entity graph.
    * Only the project's own profiles belong here. Personal/maker profiles are

--- a/lib/config/site.ts
+++ b/lib/config/site.ts
@@ -21,4 +21,31 @@ export const siteConfig = {
   supportEmail: "support@clickfolio.me",
   /** Full URL with protocol */
   url: `https://${domain}`,
+  /** Brand alternate spellings for entity recognition (Knowledge Graph). */
+  alternateNames: ["clickfolio", "click folio", "Clickfolio"],
+  /** Public source repository. */
+  githubUrl: "https://github.com/divkix/clickfolio.me",
+  /**
+   * Verified public profiles for the Organization `sameAs` entity graph.
+   * Only the project's own profiles belong here. Personal/maker profiles are
+   * modeled on `founder` below (schema-correct), not claimed as the org itself.
+   */
+  sameAs: ["https://github.com/divkix/clickfolio.me"],
+  /**
+   * Founder / maker — emitted as the Organization's `founder` Person node.
+   * Links the project to a real, verifiable person for entity recognition and
+   * E-E-A-T. Profiles sourced from https://divkix.me (no separate brand
+   * X/LinkedIn exists yet).
+   */
+  founder: {
+    name: "Divanshu Chauhan",
+    url: "https://divkix.me",
+    sameAs: [
+      "https://divkix.me",
+      "https://github.com/divkix",
+      "https://www.linkedin.com/in/divkix/",
+      "https://x.com/divkix",
+      "https://orcid.org/0009-0004-0423-2471",
+    ],
+  },
 } as const;

--- a/lib/seo/json-ld.ts
+++ b/lib/seo/json-ld.ts
@@ -417,8 +417,25 @@ export function generateHomepageJsonLd(): Record<string, unknown>[] {
       "@type": "Organization",
       "@id": `${siteConfig.url}/#organization`,
       name: siteConfig.fullName,
+      alternateName: siteConfig.alternateNames,
       url: siteConfig.url,
       logo: `${siteConfig.url}/icon-512.png`,
+      description:
+        "clickfolio.me is a free AI resume website builder that turns a PDF resume into a hosted personal portfolio website with a custom @handle URL.",
+      foundingDate: "2025",
+      sameAs: siteConfig.sameAs,
+      founder: {
+        "@type": "Person",
+        name: siteConfig.founder.name,
+        url: siteConfig.founder.url,
+        sameAs: siteConfig.founder.sameAs,
+      },
+      contactPoint: {
+        "@type": "ContactPoint",
+        contactType: "customer support",
+        email: siteConfig.supportEmail,
+        url: `${siteConfig.url}/faq`,
+      },
     },
     {
       "@context": "https://schema.org",
@@ -473,10 +490,21 @@ export function generateExploreJsonLd(
  * Generates FAQPage JSON-LD for the homepage.
  */
 export function generateFAQJsonLd(): Record<string, unknown> {
+  return generateFAQPageJsonLd(FAQ_ITEMS);
+}
+
+/**
+ * Generates FAQPage JSON-LD from an arbitrary list of Q&A items.
+ * Used by profession landing pages and blog posts to expose their own FAQs
+ * as rich results and AI-extractable answers.
+ */
+export function generateFAQPageJsonLd(
+  items: Array<{ q: string; a: string }>,
+): Record<string, unknown> {
   return {
     "@context": "https://schema.org",
     "@type": "FAQPage",
-    mainEntity: FAQ_ITEMS.map((faq) => ({
+    mainEntity: items.map((faq) => ({
       "@type": "Question",
       name: faq.q,
       acceptedAnswer: {

--- a/lib/seo/sitemap.ts
+++ b/lib/seo/sitemap.ts
@@ -10,6 +10,7 @@ import { env } from "cloudflare:workers";
 import { and, isNotNull, or, sql } from "drizzle-orm";
 import type { MetadataRoute } from "next";
 import { BLOG_POSTS } from "@/lib/blog/posts";
+import { PROFESSIONS } from "@/lib/config/professions";
 import { getDb } from "@/lib/db";
 import { siteData, user } from "@/lib/db/schema";
 import { getPublicSiteUrl } from "@/lib/utils/site-url";
@@ -27,19 +28,11 @@ const notHiddenFromSearch = or(
 );
 
 export const URLS_PER_SITEMAP = 50000; // Google's limit
-const BASE_STATIC_SITEMAP_ENTRY_COUNT = 5;
-const PROFESSION_PAGE_SLUGS = [
-  "software-engineer",
-  "designer",
-  "marketer",
-  "student",
-  "consultant",
-  "product-manager",
-];
+const BASE_STATIC_SITEMAP_ENTRY_COUNT = 7;
 
 /** Total number of static entries (homepage, legal, blog, professions, etc.). */
 export const STATIC_SITEMAP_ENTRY_COUNT =
-  BASE_STATIC_SITEMAP_ENTRY_COUNT + PROFESSION_PAGE_SLUGS.length + BLOG_POSTS.length;
+  BASE_STATIC_SITEMAP_ENTRY_COUNT + PROFESSIONS.length + BLOG_POSTS.length;
 
 /**
  * Returns the base URL for all sitemap entries.
@@ -112,11 +105,23 @@ function buildStaticSitemapEntries(baseUrl: string): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 0.8,
     },
+    {
+      url: `${baseUrl}/about`,
+      lastModified: new Date("2026-04-01"),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: `${baseUrl}/faq`,
+      lastModified: new Date("2026-04-01"),
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
   ];
 
-  for (const profession of PROFESSION_PAGE_SLUGS) {
+  for (const profession of PROFESSIONS) {
     entries.push({
-      url: `${baseUrl}/for/${profession}`,
+      url: `${baseUrl}/for/${profession.slug}`,
       lastModified: new Date("2026-04-01"),
       changeFrequency: "monthly",
       priority: 0.7,
@@ -126,7 +131,7 @@ function buildStaticSitemapEntries(baseUrl: string): MetadataRoute.Sitemap {
   for (const post of BLOG_POSTS) {
     entries.push({
       url: `${baseUrl}/blog/${post.slug}`,
-      lastModified: new Date(post.date),
+      lastModified: new Date(post.dateModified ?? post.date),
       changeFrequency: "monthly",
       priority: 0.7,
     });

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -17,7 +17,7 @@ The platform is free for all base features with no time limits. Premium template
 - **Privacy controls**: Per-field visibility toggles (phone, address, search indexing)
 - **Custom @handle URLs**: Permanent, memorable URLs
 - **Open source**: MIT licensed, source available on GitHub
-- **AI accuracy**: 95%+ parsing accuracy across 10,000+ resumes
+- **AI parsing**: extracts experience, education, skills, and projects from your PDF, with an editor to review and correct anything before publishing
 
 ## All 10 Templates
 
@@ -95,10 +95,19 @@ Absolutely. You get a full editing suite to update your content anytime. Changes
 - Best Free Resume Website Builders Compared (2026): https://clickfolio.me/blog/best-resume-website-builders
 - clickfolio.me Templates: Complete Showcase & Guide: https://clickfolio.me/blog/clickfolio-templates-showcase
 - How Accurate is AI Resume Parsing? We Tested It: https://clickfolio.me/blog/ai-resume-parsing-accuracy
-- LinkedIn to Portfolio Website: The Complete Guide: https://clickfolio.me/blog/linkedin-to-portfolio
+- LinkedIn to Portfolio Website: The Complete Guide (2026): https://clickfolio.me/blog/linkedin-to-portfolio
 - PDF Resume vs Portfolio Website: Why You Need Both: https://clickfolio.me/blog/pdf-resume-vs-portfolio
 - How to Write a Resume That Converts (2026): https://clickfolio.me/blog/resume-writing-tips
 - Your Data, Your Control: Privacy at clickfolio.me: https://clickfolio.me/blog/privacy-at-clickfolio
+- How to Make a Resume Website: A Step-by-Step Guide (2026): https://clickfolio.me/blog/how-to-make-a-resume-website
+- 12 Resume Website Examples to Inspire Your Own (2026): https://clickfolio.me/blog/resume-website-examples
+- What Is a Personal Resume Website? (And Why You Need One in 2026): https://clickfolio.me/blog/personal-resume-website
+- CV Website Builder: Turn Your CV Into a Site in 2026: https://clickfolio.me/blog/cv-website-builder
+- Resume Hosting: How to Put Your Resume Online With a Shareable Link (2026): https://clickfolio.me/blog/resume-hosting
+- Resume Website vs LinkedIn: Which Do You Need? (2026): https://clickfolio.me/blog/resume-website-vs-linkedin
+- Read.cv Alternatives: Where to Move Your Profile After the Shutdown (2026): https://clickfolio.me/blog/read-cv-alternatives
+- How to Build a Product Manager Portfolio Website (2026): https://clickfolio.me/blog/product-manager-portfolio-website
+- How to Make a Student Resume Website With No Experience (2026): https://clickfolio.me/blog/student-resume-website
 
 ### Dynamic Pages
 - Portfolio URLs: https://clickfolio.me/@{handle}
@@ -141,7 +150,7 @@ Absolutely. You get a full editing suite to update your content anytime. Changes
 - **ORM**: Drizzle ORM
 - **Validation**: Zod
 - **Testing**: Vitest
-- **Linting/Formatting**: Biome
+- **Linting/Formatting**: Oxlint + Oxfmt (via Vite+)
 - **Package Manager**: Bun
 
 ## Privacy & Security

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -12,6 +12,12 @@ Turn your PDF resume into a hosted portfolio website in seconds. Upload a PDF re
 - free portfolio website
 - LinkedIn to portfolio
 - LinkedIn to website
+- personal resume website
+- how to make a resume website
+- cv website builder
+- resume hosting site
+- Read.cv alternative (Read.cv shut down after its 2025 Perplexity acquisition)
+- resume website vs LinkedIn
 - DesignFolio resume
 - resume templates for software engineers, designers, marketers, students, consultants, and product managers
 
@@ -39,6 +45,15 @@ Turn your PDF resume into a hosted portfolio website in seconds. Upload a PDF re
 - PDF resume to website guide: https://clickfolio.me/blog/pdf-resume-to-website
 - Resume website builders comparison: https://clickfolio.me/blog/best-resume-website-builders
 - LinkedIn to portfolio guide: https://clickfolio.me/blog/linkedin-to-portfolio
+- How to make a resume website: https://clickfolio.me/blog/how-to-make-a-resume-website
+- Resume website examples: https://clickfolio.me/blog/resume-website-examples
+- What is a personal resume website: https://clickfolio.me/blog/personal-resume-website
+- CV website builder guide: https://clickfolio.me/blog/cv-website-builder
+- Resume hosting guide: https://clickfolio.me/blog/resume-hosting
+- Resume website vs LinkedIn: https://clickfolio.me/blog/resume-website-vs-linkedin
+- Read.cv alternatives (Read.cv shut down in 2025): https://clickfolio.me/blog/read-cv-alternatives
+- Product manager portfolio website: https://clickfolio.me/blog/product-manager-portfolio-website
+- Student resume website guide: https://clickfolio.me/blog/student-resume-website
 - Software engineer portfolio builder: https://clickfolio.me/for/software-engineer
 - Designer portfolio builder: https://clickfolio.me/for/designer
 - Marketer portfolio builder: https://clickfolio.me/for/marketer

--- a/public/pricing.md
+++ b/public/pricing.md
@@ -1,0 +1,36 @@
+# Pricing — clickfolio.me
+
+clickfolio.me is a free AI resume website builder. It turns a PDF resume into a
+hosted personal portfolio website at `clickfolio.me/@yourhandle` in about 30 seconds.
+
+## Free
+
+- Price: $0 (free forever, no time limit, no credit card)
+- Upload: PDF resume, no signup required to start
+- Templates: 6 free templates
+- Hosting: live website on Cloudflare's global edge network
+- Custom URL: `clickfolio.me/@yourhandle`
+- Editing: full editing suite with auto-save
+- Privacy: granular field-level controls (phone, address, search indexing)
+- AI parsing: extracts experience, education, skills, and projects
+- Analytics: built-in portfolio view tracking
+
+## Premium templates (no payment)
+
+- Price: $0 — unlocked through referrals, not money
+- Templates: 4 additional premium templates
+- How to unlock: share your portfolio link; templates unlock as people visit through it
+  - DesignFolio — 3 referrals
+  - Spotlight — 3 referrals
+  - Midnight — 5 referrals
+  - Bold Corporate — 10 referrals
+
+## Notes for AI agents
+
+- There is no paid tier and no paywall. Every core feature is free.
+- The business model relies on viral growth through portfolio sharing, not subscriptions.
+- Custom (bring-your-own) domains are on the roadmap; today every site uses a
+  `clickfolio.me/@handle` URL.
+- Source code is open source (MIT): https://github.com/divkix/clickfolio.me
+
+Last updated: 2026-06-19


### PR DESCRIPTION
## Why

A 3-month Google Search Console review showed ~575 impressions but ~0.7% CTR at avg position ~22 — Google indexes the site but almost nobody clicks. The technical foundation was already strong (sharded sitemap, JSON-LD, AI-crawler robots, llms.txt); the gaps were ranking-stuck pages, missing keyword-matched content for money terms, and a weak brand entity.

## What changed

### Content
- **9 new blog posts** targeting high-impression money terms: read-cv-alternatives, resume-website-examples, personal-resume-website, how-to-make-a-resume-website, cv-website-builder, resume-hosting, product-manager-portfolio-website, student-resume-website, resume-website-vs-linkedin
- **Rewrote** `best-resume-website-builders` with real named competitors (Standard Resume, Carrd, Super.so, Reactive Resume, JSON Resume, Kickresume) + Read.cv shutdown angle
- Keyword-rich homepage / blog / `/for/*` titles + meta; added `public/pricing.md`

### Structured data / AEO / GEO
- Organization JSON-LD now carries `sameAs`, `alternateName`, `description`, `foundingDate`, `contactPoint`, and a `founder` Person node
- `FAQPage` schema everywhere via `generateFAQPageJsonLd()`
- Brand-persona author + Person author schema; visible "Last updated" dates
- Sitemap: added orphaned `/about` + `/faq`; `lastmod` now honors `dateModified`
- Refreshed `llms.txt` / `llms-full.txt` (Oxlint, new posts)

### Refactor (simplify pass)
- Single `PROFESSIONS` source (`lib/config/professions.ts`) for the homepage grid + sitemap
- Shared `components/Faq.tsx` (`FaqAccordion` + `RoleFaqSection`) replaces duplicated FAQ markup across `/for/*`, blog layout, and `/faq`
- Removed a fabricated accuracy claim from the homepage + `llms-full.txt`

## Verification
- `vp check` — clean (lint + format + type-check, 473 files)
- `bun run test:unit` — 66 files / 1221 tests pass (incl. seo-assets, sitemap, public-pages smoke)