### PR TITLE
chore: repo cleanup — dead-branch removal, dedup, shared types, error-message bug fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## How to read & maintain this file
 
-**This file is the single source of truth for how clickfolio.me works.** An agent reading it once should understand the structure, runtime, CI, data flows, the key user-facing flows, and the *why* behind major decisions. Read it top-to-bottom before touching unfamiliar code.
+**This file is the single source of truth for how clickfolio.me works.** An agent reading it once should understand the structure, runtime, CI, data flows, the key user-facing flows, and the _why_ behind major decisions. Read it top-to-bottom before touching unfamiliar code.
 
 **MAINTENANCE PROTOCOL (mandatory).** When you discover a new important fact, decision, constraint, or gotcha while working — or you find something here that is now wrong — you **MUST** update AGENTS.md in the same change. Rules:
 
@@ -14,27 +14,27 @@
 - **Fix, don't stack.** If a statement is now inaccurate, replace it; do not leave the old claim alongside the new one.
 - Keep it dense and scannable (tables, short bullets, command blocks). Don't pad.
 
-If a decision's rationale isn't obvious from code, capture the *why* in **Design decisions & rationale**.
+If a decision's rationale isn't obvious from code, capture the _why_ in **Design decisions & rationale**.
 
 ## Stack
 
-| Layer           | Technology                                                                                 |
-| --------------- | ------------------------------------------------------------------------------------------ |
-| Runtime         | Cloudflare Workers                                                                         |
-| Framework       | [vinext](https://github.com/cloudflare/vinext) (Vite-based Next.js — NOT standard Next.js) `^0.1.4` |
+| Layer           | Technology                                                                                                                                           |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Runtime         | Cloudflare Workers                                                                                                                                   |
+| Framework       | [vinext](https://github.com/cloudflare/vinext) (Vite-based Next.js — NOT standard Next.js) `^0.1.4`                                                  |
 | Toolchain       | Vite+ (`vp`) — `vite`/`vitest` aliased via package.json `overrides` to `@voidzero-dev/vite-plus-core@0.1.24` / `@voidzero-dev/vite-plus-test@0.1.24` |
-| Package manager | `bun` (pinned `bun@1.3.14` via `packageManager`)                                            |
-| DB              | Cloudflare D1 + Drizzle ORM (SQLite)                                                       |
-| Auth            | Better Auth (Google OAuth + email/password)                                                |
-| AI parsing      | OpenRouter via Cloudflare AI Gateway (`openai/gpt-oss` models) + `unpdf` + Vercel AI SDK   |
-| Storage         | Cloudflare R2 (`CLICKFOLIO_R2_BUCKET`)                                                     |
-| Queue           | Cloudflare Queues (`CLICKFOLIO_PARSE_QUEUE`) + DLQ                                         |
-| Realtime        | Cloudflare Durable Objects (`ClickfolioStatusDO`) over WebSocket                           |
-| Email           | Cloudflare Email Workers (`EMAIL` binding)                                                 |
-| Styling         | shadcn/ui (new-york, `rsc:true`, lucide) + Tailwind CSS 4 (PostCSS-only, no `tailwind.config`) |
-| Validation      | Zod (v4 throughout)                                                                        |
-| Lint/format     | Oxlint + Oxfmt via `vp check` — NOT Biome/ESLint/Prettier                                  |
-| Testing         | Vitest (via `vite-plus/test`) + jsdom + @testing-library/react                             |
+| Package manager | `bun` (pinned `bun@1.3.14` via `packageManager`)                                                                                                     |
+| DB              | Cloudflare D1 + Drizzle ORM (SQLite)                                                                                                                 |
+| Auth            | Better Auth (Google OAuth + email/password)                                                                                                          |
+| AI parsing      | OpenRouter via Cloudflare AI Gateway (`openai/gpt-oss` models) + `unpdf` + Vercel AI SDK                                                             |
+| Storage         | Cloudflare R2 (`CLICKFOLIO_R2_BUCKET`)                                                                                                               |
+| Queue           | Cloudflare Queues (`CLICKFOLIO_PARSE_QUEUE`) + DLQ                                                                                                   |
+| Realtime        | Cloudflare Durable Objects (`ClickfolioStatusDO`) over WebSocket                                                                                     |
+| Email           | Cloudflare Email Workers (`EMAIL` binding)                                                                                                           |
+| Styling         | shadcn/ui (new-york, `rsc:true`, lucide) + Tailwind CSS 4 (PostCSS-only, no `tailwind.config`)                                                       |
+| Validation      | Zod (v4 throughout)                                                                                                                                  |
+| Lint/format     | Oxlint + Oxfmt via `vp check` — NOT Biome/ESLint/Prettier                                                                                            |
+| Testing         | Vitest (via `vite-plus/test`) + jsdom + @testing-library/react                                                                                       |
 
 ## Project Structure
 
@@ -238,17 +238,17 @@ PR requirements:
 
 CI (`.github/workflows/ci.yml`) is **9 jobs**. The five primary jobs run **in parallel** (no inter-dependencies); only the downstream jobs have `needs`. `ci-success` is the single required gate. Workflow-level `permissions: { contents: read, pull-requests: write }`. `concurrency` group `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`. Triggers: push + PR on `main`/`master`. **All actions are pinned to full commit SHAs**; every checkout sets `persist-credentials: false`.
 
-| Job                 | `needs`                                                 | Command (reproduce locally)                | Gates / notes                                                                 |
-| ------------------- | ------------------------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------- |
-| `quality`           | —                                                       | `vp check` (via `voidzero-dev/setup-vp@v1`, `node-version:22`, `cache:true`)| Lint+format+type-check (Vite+). Only job using setup-vp; no setup-node. |
-| `type-check`        | —                                                       | `bun run type-check` (`tsc --noEmit`)      | Strict TS flags are errors. `oven-sh/setup-bun` only. Parallel.               |
-| `unit-tests`        | —                                                       | `bun run test:unit -- --coverage`          | `pool:threads`,`retry:0`. Uploads `unit-coverage-report` → `coverage/unit/` (`if: always()`). |
-| `integration-tests` | —                                                       | `bun run test:integration -- --coverage`   | `retry:2`,10s. Uploads `integration-coverage-report` → `coverage/integration/`. |
-| `security-tests`    | —                                                       | `bun run test:security -- --coverage`      | `pool:forks`,`retry:0`,15s. Uploads `security-coverage-report` → `coverage/security/`. |
-| `coverage-summary`  | unit, integration, security                             | (PR-only) `romeovs/lcov-reporter-action`   | **PR events only.** Downloads all 3 artifacts but feeds ONLY `coverage/unit/coverage.lcov` (title 'Unit Test Coverage'). |
-| `coverage-gate`     | unit, integration, security                             | `bun run test:coverage`                    | **Hard 80% gate** across lines/statements/functions/branches.                 |
-| `build`             | quality, type-check, unit, integration, security, coverage-gate | `bunx knip` + `bun run build`      | Production build; `knip` fails on unused exports. Uses BOTH `setup-node@22` + `oven-sh/setup-bun`. |
-| `ci-success`        | all 7 above (`if: always()`)                            | shell check of each `needs.*.result`       | **The required status check.** Fails if any upstream job != success.          |
+| Job                 | `needs`                                                         | Command (reproduce locally)                                                  | Gates / notes                                                                                                            |
+| ------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `quality`           | —                                                               | `vp check` (via `voidzero-dev/setup-vp@v1`, `node-version:22`, `cache:true`) | Lint+format+type-check (Vite+). Only job using setup-vp; no setup-node.                                                  |
+| `type-check`        | —                                                               | `bun run type-check` (`tsc --noEmit`)                                        | Strict TS flags are errors. `oven-sh/setup-bun` only. Parallel.                                                          |
+| `unit-tests`        | —                                                               | `bun run test:unit -- --coverage`                                            | `pool:threads`,`retry:0`. Uploads `unit-coverage-report` → `coverage/unit/` (`if: always()`).                            |
+| `integration-tests` | —                                                               | `bun run test:integration -- --coverage`                                     | `retry:2`,10s. Uploads `integration-coverage-report` → `coverage/integration/`.                                          |
+| `security-tests`    | —                                                               | `bun run test:security -- --coverage`                                        | `pool:forks`,`retry:0`,15s. Uploads `security-coverage-report` → `coverage/security/`.                                   |
+| `coverage-summary`  | unit, integration, security                                     | (PR-only) `romeovs/lcov-reporter-action`                                     | **PR events only.** Downloads all 3 artifacts but feeds ONLY `coverage/unit/coverage.lcov` (title 'Unit Test Coverage'). |
+| `coverage-gate`     | unit, integration, security                                     | `bun run test:coverage`                                                      | **Hard 80% gate** across lines/statements/functions/branches.                                                            |
+| `build`             | quality, type-check, unit, integration, security, coverage-gate | `bunx knip` + `bun run build`                                                | Production build; `knip` fails on unused exports. Uses BOTH `setup-node@22` + `oven-sh/setup-bun`.                       |
+| `ci-success`        | all 7 above (`if: always()`)                                    | shell check of each `needs.*.result`                                         | **The required status check.** Fails if any upstream job != success.                                                     |
 
 Because the test npm scripts already inject `--config vitest.<suite>.config.ts`, the trailing `-- --coverage` is appended to that. Bun cache key = `${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}` (lockfile is `bun.lock`).
 
@@ -270,20 +270,20 @@ The real entrypoint. Wraps the vinext handler and adds:
   - `"0 3 * * *"` — DB cleanup / expired sessions (`lib/cron/cleanup.ts` `performCleanup`)
   - `"0 4 * * *"` — disposable domain KV sync (`lib/cron/sync-disposable-domains.ts`)
   - `"*/15 * * * *"` — orphan resume recovery (`lib/cron/recover-orphaned.ts`)
-- **WebSocket upgrade routing** (`/ws/resume-status`) → Durable Object. Regex-extracts the session token from the raw `Cookie` header (`/better-auth\.session_token=([^;]+)/`) as a **cheap presence pre-check only** — the real auth passes the FULL raw Cookie header to `auth.api.getSession({ headers })`. Verifies D1 resume ownership via `getSessionDbForWebhook` (`"first-primary"`, no cookies — *not* `getDb`), then forwards to the DO (`idFromName(resumeId)`) injecting the `X-Authenticated-User-Id` header.
+- **WebSocket upgrade routing** (`/ws/resume-status`) → Durable Object. Regex-extracts the session token from the raw `Cookie` header (`/better-auth\.session_token=([^;]+)/`) as a **cheap presence pre-check only** — the real auth passes the FULL raw Cookie header to `auth.api.getSession({ headers })`. Verifies D1 resume ownership via `getSessionDbForWebhook` (`"first-primary"`, no cookies — _not_ `getDb`), then forwards to the DO (`idFromName(resumeId)`) injecting the `X-Authenticated-User-Id` header.
 - **Security headers** injected on every non-WS response via a **local `SECURITY_HEADERS` constant defined in `worker/index.ts`** (lines 32–38): HSTS `max-age=31536000; includeSubDomains` (**1yr, NO `preload`**), X-Content-Type-Options, X-Frame-Options:DENY, Referrer-Policy, Permissions-Policy `camera=(), microphone=(), geolocation=()`, and **NO X-XSS-Protection**. ⚠️ This is DISTINCT from the `SECURITY_HEADERS` in `lib/utils/security-headers.ts` (see API Routes) — editing one does NOT change the other. The Content-Security-Policy itself originates in `next.config.ts` `headers()`, not here (see below).
 
 ### Cloudflare bindings (`wrangler.jsonc`)
 
-| Binding                         | Type   | Name                     | Notes                                                                     |
-| ------------------------------- | ------ | ------------------------ | ------------------------------------------------------------------------- |
-| `CLICKFOLIO_DB`                 | D1     | `clickfolio-db`          | `database_id 37cf1935-96c5-40c8-aa2e-0d0655f9b652`. Use via `getDb()` / session variants |
-| `CLICKFOLIO_R2_BUCKET`          | R2     | `clickfolio-bucket`      | Use via `lib/r2.ts` helpers                                               |
-| `CLICKFOLIO_DISPOSABLE_DOMAINS` | KV     | `id 6fe2480a4f4d46a9970eb2c441ecf38a` | Disposable email list (synced by cron, KV key `disposable-domains`) |
-| `CLICKFOLIO_PARSE_QUEUE`        | Queue  | `clickfolio-parse-queue` | `max_batch_size:1`, `max_retries:3`, DLQ `clickfolio-parse-dlq` (`max_batch_size:1,max_retries:0`) |
-| `CLICKFOLIO_STATUS_DO`          | DO     | `ClickfolioStatusDO`     | Hibernatable WebSocket parse status                                       |
-| `EMAIL`                         | Email  | `send_email`             | Transactional email via CF Email Workers; sender: `noreply@clickfolio.me` |
-| `ASSETS`                        | Static | `dist/client`            | Static asset binding                                                      |
+| Binding                         | Type   | Name                                  | Notes                                                                                              |
+| ------------------------------- | ------ | ------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `CLICKFOLIO_DB`                 | D1     | `clickfolio-db`                       | `database_id 37cf1935-96c5-40c8-aa2e-0d0655f9b652`. Use via `getDb()` / session variants           |
+| `CLICKFOLIO_R2_BUCKET`          | R2     | `clickfolio-bucket`                   | Use via `lib/r2.ts` helpers                                                                        |
+| `CLICKFOLIO_DISPOSABLE_DOMAINS` | KV     | `id 6fe2480a4f4d46a9970eb2c441ecf38a` | Disposable email list (synced by cron, KV key `disposable-domains`)                                |
+| `CLICKFOLIO_PARSE_QUEUE`        | Queue  | `clickfolio-parse-queue`              | `max_batch_size:1`, `max_retries:3`, DLQ `clickfolio-parse-dlq` (`max_batch_size:1,max_retries:0`) |
+| `CLICKFOLIO_STATUS_DO`          | DO     | `ClickfolioStatusDO`                  | Hibernatable WebSocket parse status                                                                |
+| `EMAIL`                         | Email  | `send_email`                          | Transactional email via CF Email Workers; sender: `noreply@clickfolio.me`                          |
+| `ASSETS`                        | Static | `dist/client`                         | Static asset binding                                                                               |
 
 **Compat:** `compatibility_date: "2026-01-22"`, `compatibility_flags: ["nodejs_compat","global_fetch_strictly_public"]`. `workers_dev: true` but `preview_urls: false` (intentionally disabled). Custom-domain routes (`clickfolio.me`, `www.clickfolio.me`) are kept in wrangler.jsonc specifically so CI/wrangler deploy does not remove them. **Smart placement** is on (`placement.mode: "smart"`) since the Worker is origin-bound (D1/R2/AI), not edge-latency-bound. **Observability at 100% head sampling** (`head_sampling_rate: 1` top-level + under `logs`, `persist: true`, `invocation_logs: true`).
 
@@ -320,12 +320,12 @@ The real entrypoint. Wraps the vinext handler and adds:
 
 All in `lib/db/session.ts`. Using the wrong variant causes stale-read bugs, FK errors, or read-your-own-writes inconsistency.
 
-| Function                           | When to use                                                                                        |
-| ---------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `getDb(env.CLICKFOLIO_DB)`         | Read-only or non-user-facing queries. **WeakMap-cached** per binding (once-per-isolate drizzle parse) |
+| Function                           | When to use                                                                                                                                              |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getDb(env.CLICKFOLIO_DB)`         | Read-only or non-user-facing queries. **WeakMap-cached** per binding (once-per-isolate drizzle parse)                                                    |
 | `getSessionDb(d1)`                 | Authenticated page/API routes — reads `d1-session-bookmark` cookie (else `"first-unconstrained"`), provides `captureBookmark()` for read-your-own-writes |
-| `getSessionDbWithPrimaryFirst(d1)` | Immediately after user creation (`"first-primary"` — avoids FK errors before D1 replication)       |
-| `getSessionDbForWebhook(d1)`       | Queue consumers, cron handlers, WebSocket handlers (no cookies; `"first-primary"`, no bookmark)    |
+| `getSessionDbWithPrimaryFirst(d1)` | Immediately after user creation (`"first-primary"` — avoids FK errors before D1 replication)                                                             |
+| `getSessionDbForWebhook(d1)`       | Queue consumers, cron handlers, WebSocket handlers (no cookies; `"first-primary"`, no bookmark)                                                          |
 
 ⚠️ The three session variants build a **FRESH `drizzle(session, {schema})` on every call** (each wraps a per-request `d1.withSession(...)`); they are NOT WeakMap-cached. Only `getDb()` gets the once-per-isolate cache.
 
@@ -380,7 +380,7 @@ Key routes not obvious from directory names:
 - `GET /api/cron/*` — manual cron triggers (`cleanup`, `cleanup-r2`, `recover-orphaned`, `sync-domains`); `Bearer ${CRON_SECRET}` (`requireCronAuth`, fail-closed).
 - `GET /api/health` — `dynamic='force-dynamic'`, unauthenticated public liveness probe. Checks D1 (`SELECT 1`), R2 (`list({limit:1})`), AI gateway **config presence only** (no AI call). all healthy→200 `healthy`; any unhealthy→503; else 200 `degraded`. Returns per-service `latencyMs`.
 - `GET /api/og/home` — **SVG-only** hardcoded branded 1200×630 SVG (`max-age=604800`, no DB/auth/params).
-- `GET /api/og/[handle]` — **renders a REAL PNG** via `@cf-wasm/resvg/workerd` (`Resvg.async(svg,{fitTo:{mode:'width',value:1200}}).render().asPng()`), 1200×630, `Cache-Control: public, max-age=3600, swr=86400`. Fallback chain on not-found OR resvg failure: `renderFallbackPng` → `renderLastResort` (raw SVG, `max-age=300`). Only the `@vercel/og` *import path* is stubbed (`lib/stubs/og-stub.js`); `@cf-wasm/resvg` is a LIVE dependency.
+- `GET /api/og/[handle]` — **renders a REAL PNG** via `@cf-wasm/resvg/workerd` (`Resvg.async(svg,{fitTo:{mode:'width',value:1200}}).render().asPng()`), 1200×630, `Cache-Control: public, max-age=3600, swr=86400`. Fallback chain on not-found OR resvg failure: `renderFallbackPng` → `renderLastResort` (raw SVG, `max-age=300`). Only the `@vercel/og` _import path_ is stubbed (`lib/stubs/og-stub.js`); `@cf-wasm/resvg` is a LIVE dependency.
 - Sitemap: `/sitemap.xml` → `/api/sitemap-index`; `/sitemap/:id.xml` → `/api/sitemap/:id` (`next.config.ts` `rewrites()`). `redirects()` 308s bare `/:handle` → `/@handle` (reserved-path negative-lookahead). See SEO section for sharding.
 
 ### Auth patterns
@@ -420,6 +420,7 @@ Auth is **Better Auth** (Google OAuth + email/password) backed by D1 via the Dri
 - **`lib/utils/format.ts`** `formatRelativeTime()` is deterministic (no `Intl.RelativeTimeFormat`/locale) to avoid SSR hydration mismatches. **NOT shared, despite the name:** all 4 admin pages (`admin/page.tsx`, `referrals/`, `resumes/`, `users/`) each define their OWN local `formatRelativeTime(dateStr)` with DIVERGING output ('Xh/Xd ago' vs adds 'Xm ago' vs 'Today'/'Yesterday'/'Xw ago' with `toLocaleDateString`); `components/ui/save-indicator.tsx` has yet another taking a `Date` (uses locale-dependent `toLocaleTimeString`, safe only because it's `"use client"` and never SSRs). Don't assume "the shared formatter" is used. **`lib/utils/site-url.ts`** `getPublicSiteUrl()` & **`lib/utils/environment.ts`** `isLocalEnvironment()` both read `BETTER_AUTH_URL` (default `https://clickfolio.me`) NOT `NODE_ENV` (wrangler bakes NODE_ENV=production at build time).
 
 **Client-only vs server-only split** (importing the wrong one breaks):
+
 - **Client-only** (browser APIs): `lib/utils/clipboard.ts`, `share.ts`, `wait-for-completion.ts`, `errors.ts` (imports `sonner`+`window.location`), `pending-upload-client.ts`, client fns in `referral.ts`.
 - **Server-only** (import `cloudflare:workers` env at module top): `lib/rate-limit/ip.ts`, `user.ts`, `referral.ts`.
 - **Isomorphic** (Web Crypto only): `lib/utils/hash.ts`, `pending-upload-cookie.ts`, `lib/password/hibp.ts`, `sanitization.ts`, `xml.ts`, `analytics.ts`.
@@ -445,7 +446,7 @@ Auth is **Better Auth** (Google OAuth + email/password) backed by D1 via the Dri
 
 **A request, end to end:**
 
-1. **`proxy.ts` (edge).** For `protectedRoutes` (`/dashboard /edit /settings /waiting /wizard`) checks only that a session cookie is *present* — no D1, no signature/expiry validation. Cookie name has two forms: `better-auth.session_token` (dev/HTTP) and `__Secure-better-auth.session_token` (prod HTTPS); proxy checks both.
+1. **`proxy.ts` (edge).** For `protectedRoutes` (`/dashboard /edit /settings /waiting /wizard`) checks only that a session cookie is _present_ — no D1, no signature/expiry validation. Cookie name has two forms: `better-auth.session_token` (dev/HTTP) and `__Secure-better-auth.session_token` (prod HTTPS); proxy checks both.
 2. **`worker/index.ts`.** The real entrypoint. WebSocket upgrades to `/ws/resume-status` are intercepted here (auth + ownership → DO). Everything else flows to the vinext handler. Queue and cron invocations also enter here. The worker's `SECURITY_HEADERS` are injected on every response.
 3. **Page (RSC) or API route.** Pages call `getServerSession()` and self-redirect; APIs call the `requireAuth*` helpers. DB access goes through the correct session variant. On first call this isolate, `getAuth()` builds + caches the Better Auth instance.
 
@@ -568,6 +569,7 @@ Auth is **Better Auth** (Google OAuth + email/password) backed by D1 via the Dri
 ### Resume templates & theme registry
 
 **Adding a template — update ALL of these together** (TS `Record<ThemeId,...>` catches most; the registry-sync test catches the rest):
+
 1. `THEME_IDS` const tuple in `lib/templates/theme-ids.ts` (single source of truth; `ThemeId = typeof THEME_IDS[number]`).
 2. `THEME_METADATA[id]` (`name/description/category/preview/referralsRequired`).
 3. `themeToShareVariant[id]` (UNDERSCORE id → KEBAB `SharePopoverVariant`).
@@ -591,33 +593,33 @@ Auth is **Better Auth** (Google OAuth + email/password) backed by D1 via the Dri
 
 ## Design decisions & rationale
 
-| Decision | Why |
-| -------- | --- |
-| **`getAuth()` built once per isolate, WeakMap-cached by D1 binding** (`authInstanceCache`) | Avoids re-running schema parsing / plugin init / route generation on every request. The instance is stateless — headers/cookies are passed per call. |
-| **D1 binding wrapped in a date-serializing `Proxy`** (`wrapD1WithDateSerialization`, cached in `d1ProxyCache` WeakMap) | Better Auth's drizzle-adapter accepts `supportsDates:false` but never forwards it, and D1 can't `.bind()` `Date` objects. The Proxy converts `Date` → ISO string on `.bind()`. (This is also why ALL timestamp columns are stored as `text`.) |
-| **Proxy does cookie-presence-only checks (no D1)** | D1 is not available in proxy/middleware on Workers. Real enforcement is deferred to page/API layers; the proxy is just a cheap edge bounce. |
-| **Admin re-reads `isAdmin` from D1 every time** | So revoking admin is immediate and a stale `cookieCache` can't grant admin. Never trust session claims for admin. |
-| **Four DB session variants; only `getDb()` is cached** | Read-your-own-writes needs the `d1-session-bookmark` cookie; post-signup needs `"first-primary"` to avoid FK errors before replication; webhook/cron/WS have no cookies. Session variants wrap per-request `d1.withSession()` so they can't be isolate-cached. |
-| **Resume-complete UPDATE + siteData upsert always in one `db.batch()`** | A crash between them leaves the resume `completed` with no siteData, which the idempotency guard then permanently skips — silent data loss. |
-| **`pendingR2Deletions` rows written BEFORE the delete batch; no user FK** | The user row is gone when the 2 AM cron retries the R2 delete; recording the key durably first preserves GDPR cleanup. |
-| **fileHash dedup/cache is PER-USER** | Security: never leak parsed content across users; still saves a re-parse on identical re-uploads by the same user. |
-| **RETRYABLE errors keep status `processing` (no `failed`)** | Avoids showing the user a false-negative failure mid-retry; `failed` is written only on non-retryable errors or by the DLQ after exhaustion (Issues #83/#91). |
-| **`unknown` queue error is NON-retryable** | An unrecognized error message goes straight to DLQ rather than burning retries on something we can't classify as transient. |
-| **Cron triggers called directly in `worker/index.ts`** (not HTTP self-fetch) | Avoids double-billing the Worker for each scheduled run. |
-| **Smart placement enabled** | The Worker is origin-bound (D1/R2/AI), not edge-latency-bound, so running near the bindings beats running near the user. |
-| **Server password validation is length-only; strength is client-side** | Bundling ~1.73 MB of zxcvbn dictionaries into the Worker is unacceptable; `@zxcvbn-ts/*` is SSR-stubbed. |
-| **Stubs for CF-incompatible packages** (`@vercel/og`, `@zxcvbn-ts/*`, `zod/v3`, `async_hooks`, `cloudflare:workers`) | These don't run on Workers / cause dual-bundle issues; stubs keep the bundle valid and small. `zod/v3` stub drops a dead 128 KB AI-SDK path; `@vercel/og` stub drops ~2 MB resvg+yoga (the live OG PNG path uses `@cf-wasm/resvg`). |
-| **IP addresses SHA-256 hashed before storage** | GDPR-friendly rate limiting with no raw PII at rest. |
-| **Claim-check pattern (`pending_upload` signed cookie)** | Lets anonymous users upload *before* authenticating, then bind the temp R2 object to the new account on claim. |
-| **Disposable-email check is fail-OPEN** | Only an explicit `APIError` from the hook blocks signup; KV/network errors let signup through (availability over strictness). Email verification is the safety net. |
-| **`theme-ids.ts` is a zero-component-import data module** | Lets API routes / server code read theme metadata + unlock logic without pulling template component bundles into server routes. |
-| **`getRelatedProfiles` avoids `ORDER BY random()`** | Random sort isn't indexable on D1; a random OFFSET into a stable `orderBy(handle)` window + in-memory shuffle is cheap and indexable. |
-| **Public reads skip Zod re-validation of D1 content** | D1 is a trusted source; skipping redundant validation saves 200–400 ms (JSON.parse-with-try/catch only). |
-| **Env detection keys off `BETTER_AUTH_URL`, not `NODE_ENV`** | wrangler bakes `NODE_ENV=production` at build time, so it's unreliable for local-vs-prod (e.g. `bun run preview`). |
+| Decision                                                                                                               | Why                                                                                                                                                                                                                                                            |
+| ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`getAuth()` built once per isolate, WeakMap-cached by D1 binding** (`authInstanceCache`)                             | Avoids re-running schema parsing / plugin init / route generation on every request. The instance is stateless — headers/cookies are passed per call.                                                                                                           |
+| **D1 binding wrapped in a date-serializing `Proxy`** (`wrapD1WithDateSerialization`, cached in `d1ProxyCache` WeakMap) | Better Auth's drizzle-adapter accepts `supportsDates:false` but never forwards it, and D1 can't `.bind()` `Date` objects. The Proxy converts `Date` → ISO string on `.bind()`. (This is also why ALL timestamp columns are stored as `text`.)                  |
+| **Proxy does cookie-presence-only checks (no D1)**                                                                     | D1 is not available in proxy/middleware on Workers. Real enforcement is deferred to page/API layers; the proxy is just a cheap edge bounce.                                                                                                                    |
+| **Admin re-reads `isAdmin` from D1 every time**                                                                        | So revoking admin is immediate and a stale `cookieCache` can't grant admin. Never trust session claims for admin.                                                                                                                                              |
+| **Four DB session variants; only `getDb()` is cached**                                                                 | Read-your-own-writes needs the `d1-session-bookmark` cookie; post-signup needs `"first-primary"` to avoid FK errors before replication; webhook/cron/WS have no cookies. Session variants wrap per-request `d1.withSession()` so they can't be isolate-cached. |
+| **Resume-complete UPDATE + siteData upsert always in one `db.batch()`**                                                | A crash between them leaves the resume `completed` with no siteData, which the idempotency guard then permanently skips — silent data loss.                                                                                                                    |
+| **`pendingR2Deletions` rows written BEFORE the delete batch; no user FK**                                              | The user row is gone when the 2 AM cron retries the R2 delete; recording the key durably first preserves GDPR cleanup.                                                                                                                                         |
+| **fileHash dedup/cache is PER-USER**                                                                                   | Security: never leak parsed content across users; still saves a re-parse on identical re-uploads by the same user.                                                                                                                                             |
+| **RETRYABLE errors keep status `processing` (no `failed`)**                                                            | Avoids showing the user a false-negative failure mid-retry; `failed` is written only on non-retryable errors or by the DLQ after exhaustion (Issues #83/#91).                                                                                                  |
+| **`unknown` queue error is NON-retryable**                                                                             | An unrecognized error message goes straight to DLQ rather than burning retries on something we can't classify as transient.                                                                                                                                    |
+| **Cron triggers called directly in `worker/index.ts`** (not HTTP self-fetch)                                           | Avoids double-billing the Worker for each scheduled run.                                                                                                                                                                                                       |
+| **Smart placement enabled**                                                                                            | The Worker is origin-bound (D1/R2/AI), not edge-latency-bound, so running near the bindings beats running near the user.                                                                                                                                       |
+| **Server password validation is length-only; strength is client-side**                                                 | Bundling ~1.73 MB of zxcvbn dictionaries into the Worker is unacceptable; `@zxcvbn-ts/*` is SSR-stubbed.                                                                                                                                                       |
+| **Stubs for CF-incompatible packages** (`@vercel/og`, `@zxcvbn-ts/*`, `zod/v3`, `async_hooks`, `cloudflare:workers`)   | These don't run on Workers / cause dual-bundle issues; stubs keep the bundle valid and small. `zod/v3` stub drops a dead 128 KB AI-SDK path; `@vercel/og` stub drops ~2 MB resvg+yoga (the live OG PNG path uses `@cf-wasm/resvg`).                            |
+| **IP addresses SHA-256 hashed before storage**                                                                         | GDPR-friendly rate limiting with no raw PII at rest.                                                                                                                                                                                                           |
+| **Claim-check pattern (`pending_upload` signed cookie)**                                                               | Lets anonymous users upload _before_ authenticating, then bind the temp R2 object to the new account on claim.                                                                                                                                                 |
+| **Disposable-email check is fail-OPEN**                                                                                | Only an explicit `APIError` from the hook blocks signup; KV/network errors let signup through (availability over strictness). Email verification is the safety net.                                                                                            |
+| **`theme-ids.ts` is a zero-component-import data module**                                                              | Lets API routes / server code read theme metadata + unlock logic without pulling template component bundles into server routes.                                                                                                                                |
+| **`getRelatedProfiles` avoids `ORDER BY random()`**                                                                    | Random sort isn't indexable on D1; a random OFFSET into a stable `orderBy(handle)` window + in-memory shuffle is cheap and indexable.                                                                                                                          |
+| **Public reads skip Zod re-validation of D1 content**                                                                  | D1 is a trusted source; skipping redundant validation saves 200–400 ms (JSON.parse-with-try/catch only).                                                                                                                                                       |
+| **Env detection keys off `BETTER_AUTH_URL`, not `NODE_ENV`**                                                           | wrangler bakes `NODE_ENV=production` at build time, so it's unreliable for local-vs-prod (e.g. `bun run preview`).                                                                                                                                             |
 
 ## Common gotchas / footguns
 
-- **TWO different `SECURITY_HEADERS` constants exist and DIFFER.** `worker/index.ts` (every response): HSTS 1yr, NO preload, NO X-XSS-Protection. `lib/utils/security-headers.ts` (API helper responses + `lib/rate-limit/user.ts`): HSTS 2yr WITH preload + `X-XSS-Protection: 0`. They're separate constants — editing one doesn't change the other; on API JSON responses both merge and the worker's HSTS wins. The CSP+HSTS *origin* is `next.config.ts` `headers()`.
+- **TWO different `SECURITY_HEADERS` constants exist and DIFFER.** `worker/index.ts` (every response): HSTS 1yr, NO preload, NO X-XSS-Protection. `lib/utils/security-headers.ts` (API helper responses + `lib/rate-limit/user.ts`): HSTS 2yr WITH preload + `X-XSS-Protection: 0`. They're separate constants — editing one doesn't change the other; on API JSON responses both merge and the worker's HSTS wins. The CSP+HSTS _origin_ is `next.config.ts` `headers()`.
 - **`(protected)/layout.tsx` does NOT enforce auth.** Every page under it must call `getServerSession()` and `redirect('/')` itself. `/themes` relies entirely on its own page check (not in proxy's `protectedRoutes`).
 - **`proxy.ts` is presence-only.** A forged/expired-but-present cookie passes. `/admin` and `/themes` are not in proxy's `protectedRoutes` at all.
 - **Cookie name has two forms.** `better-auth.session_token` (dev/HTTP) and `__Secure-better-auth.session_token` (prod HTTPS). `proxy.ts`/account-delete handle both. The WS regex `/better-auth\.session_token=([^;]+)/` matches the prefixed name in prod **by coincidence**. Any EXACT lookup of only the unprefixed name breaks in production.

--- a/__tests__/unit/components/branch-heavy-components.test.tsx
+++ b/__tests__/unit/components/branch-heavy-components.test.tsx
@@ -254,7 +254,7 @@ describe("branch-heavy component interactions", () => {
       expect(mocks.router.refresh).toHaveBeenCalled();
 
       vi.mocked(fetch).mockResolvedValueOnce(
-        Response.json({ message: "Handle is taken" }, { status: 409 }),
+        Response.json({ error: "Handle is taken" }, { status: 409 }),
       );
       rerender(<HandleForm currentHandle="avery" />);
 

--- a/__tests__/unit/components/settings-forms.test.tsx
+++ b/__tests__/unit/components/settings-forms.test.tsx
@@ -122,7 +122,7 @@ describe("PrivacySettingsForm", () => {
   it("surfaces API and thrown privacy update failures", async () => {
     const user = userEvent.setup();
     vi.mocked(globalThis.fetch)
-      .mockResolvedValueOnce(Response.json({ message: "Privacy rejected" }, { status: 400 }))
+      .mockResolvedValueOnce(Response.json({ error: "Privacy rejected" }, { status: 400 }))
       .mockRejectedValueOnce("network");
 
     render(

--- a/app/(admin)/admin/analytics/page.tsx
+++ b/app/(admin)/admin/analytics/page.tsx
@@ -9,8 +9,7 @@ import { AdminTrafficChart } from "@/components/admin/AdminTrafficChart";
 import { HorizontalBarChart } from "@/components/admin/HorizontalBarChart";
 import { StatCard } from "@/components/admin/StatCard";
 import { Skeleton } from "@/components/ui/skeleton";
-
-type Period = "7d" | "30d" | "90d";
+import type { Period } from "@/lib/types/api";
 
 interface AnalyticsData {
   totals: {

--- a/app/(protected)/wizard/page.tsx
+++ b/app/(protected)/wizard/page.tsx
@@ -18,17 +18,12 @@ import { UploadStep } from "@/components/wizard/UploadStep";
 import { YouAreLiveModal } from "@/components/YouAreLiveModal";
 import { useSession } from "@/lib/auth/client";
 import { DEFAULT_THEME, type ThemeId } from "@/lib/templates/theme-ids";
+import type { ClaimResponse } from "@/lib/types/api";
 import type { ResumeContent } from "@/lib/types/database";
 import { clearPendingUploadCookie } from "@/lib/utils/pending-upload-client";
 import { waitForResumeCompletion } from "@/lib/utils/wait-for-completion";
 
 // Type definitions for API responses
-interface ClaimResponse {
-  resume_id: string;
-  cached?: boolean;
-  error?: string;
-}
-
 interface SiteDataResponse {
   id?: string;
   content?: ResumeContent;

--- a/app/[handle]/page.tsx
+++ b/app/[handle]/page.tsx
@@ -46,7 +46,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const handle = rawHandle.slice(1);
 
   // Early reject invalid formats — skips DB query for bot probes, missing files, malformed paths
-  // See: lib/utils/handle-validation.ts for why this exists
+  // See: lib/rate-limit/handle-validation.ts for why this exists
   if (!isValidHandleFormat(handle)) {
     return {
       title: "Not Found",
@@ -145,7 +145,7 @@ export default async function HandlePage({ params }: PageProps) {
   const handle = rawHandle.slice(1);
 
   // Early reject invalid formats — skips DB query for bot probes, missing files, malformed paths
-  // See: lib/utils/handle-validation.ts for why this exists
+  // See: lib/rate-limit/handle-validation.ts for why this exists
   if (!isValidHandleFormat(handle)) {
     notFound();
   }

--- a/app/api/admin/analytics/route.ts
+++ b/app/api/admin/analytics/route.ts
@@ -26,6 +26,7 @@
 import { env } from "cloudflare:workers";
 import { requireAdminAuthForApi } from "@/lib/auth/admin";
 import { getMetrics, getPageviews, getStats } from "@/lib/umami/client";
+import { lastNUtcDays } from "@/lib/utils/date-axis";
 import {
   createErrorResponse,
   createSuccessResponse,
@@ -118,15 +119,16 @@ export async function GET(request: Request) {
 
     // Daily breakdown — map Umami {x, y} to {date, views, unique}
     // Umami returns x as full ISO timestamp (e.g. "2026-02-09T00:00:00Z") when timezone=UTC,
-    // so normalize to YYYY-MM-DD for consistent date matching in fillMissingDates.
+    // so normalize to YYYY-MM-DD for consistent date matching across the date axis.
     const sessionMap = new Map(pageviews.sessions.map((s) => [s.x.slice(0, 10), s.y]));
-    const daily = fillMissingDates(
-      pageviews.pageviews.map((p) => ({
-        date: p.x.slice(0, 10),
-        views: p.y,
-        unique: sessionMap.get(p.x.slice(0, 10)) ?? 0,
-      })),
-      days,
+    const dailyData = pageviews.pageviews.map((p) => ({
+      date: p.x.slice(0, 10),
+      views: p.y,
+      unique: sessionMap.get(p.x.slice(0, 10)) ?? 0,
+    }));
+    const dailyMap = new Map(dailyData.map((d) => [d.date, d]));
+    const daily = lastNUtcDays(days).map(
+      (date) => dailyMap.get(date) ?? { date, views: 0, unique: 0 },
     );
 
     // Top profiles — filter URL metrics to profile paths only
@@ -186,20 +188,4 @@ export async function GET(request: Request) {
       503,
     );
   }
-}
-
-function fillMissingDates(
-  data: Array<{ date: string; views: number; unique: number }>,
-  days: number,
-): Array<{ date: string; views: number; unique: number }> {
-  const dataMap = new Map(data.map((d) => [d.date, d]));
-  const result: Array<{ date: string; views: number; unique: number }> = [];
-
-  for (let i = days - 1; i >= 0; i--) {
-    const date = new Date(Date.now() - i * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-    const existing = dataMap.get(date);
-    result.push(existing ?? { date, views: 0, unique: 0 });
-  }
-
-  return result;
 }

--- a/app/api/admin/stats/route.ts
+++ b/app/api/admin/stats/route.ts
@@ -26,6 +26,7 @@ import { requireAdminAuthForApi } from "@/lib/auth/admin";
 import { getDb } from "@/lib/db";
 import { resumes, siteData, user } from "@/lib/db/schema";
 import { getPageviews, getStats } from "@/lib/umami/client";
+import { lastNUtcDays } from "@/lib/utils/date-axis";
 import {
   createErrorResponse,
   createSuccessResponse,
@@ -97,10 +98,11 @@ export async function GET() {
     // Fill missing dates for sparkline from Umami pageviews
     // Umami returns x as full ISO timestamp (e.g. "2026-02-09T00:00:00Z") when timezone=UTC,
     // so normalize to YYYY-MM-DD for consistent date matching.
-    const filledDailyViews = fillMissingDates(
-      umamiPageviews.pageviews.map((p) => ({ date: p.x.slice(0, 10), views: p.y })),
-      7,
-    );
+    const viewsMap = new Map(umamiPageviews.pageviews.map((p) => [p.x.slice(0, 10), p.y]));
+    const filledDailyViews = lastNUtcDays(7).map((date) => ({
+      date,
+      views: viewsMap.get(date) ?? 0,
+    }));
 
     return createSuccessResponse({
       totalUsers: userStats[0]?.total ?? 0,
@@ -118,19 +120,4 @@ export async function GET() {
     console.error("[admin/stats] Error:", err);
     return createErrorResponse("Stats temporarily unavailable", ERROR_CODES.INTERNAL_ERROR, 503);
   }
-}
-
-function fillMissingDates(
-  data: Array<{ date: string; views: number }>,
-  days: number,
-): Array<{ date: string; views: number }> {
-  const dataMap = new Map(data.map((d) => [d.date, d.views]));
-  const result: Array<{ date: string; views: number }> = [];
-
-  for (let i = days - 1; i >= 0; i--) {
-    const date = new Date(Date.now() - i * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-    result.push({ date, views: dataMap.get(date) ?? 0 });
-  }
-
-  return result;
 }

--- a/app/api/analytics/stats/route.ts
+++ b/app/api/analytics/stats/route.ts
@@ -29,6 +29,7 @@ import { eq } from "drizzle-orm";
 import { requireAuthWithUserValidation } from "@/lib/auth/middleware";
 import { handleChanges } from "@/lib/db/schema";
 import { getMetrics, getPageviews, getStats } from "@/lib/umami/client";
+import { lastNUtcDays } from "@/lib/utils/date-axis";
 import {
   createErrorResponse,
   createSuccessResponse,
@@ -234,7 +235,11 @@ export async function GET(request: Request) {
 
     // Fill missing dates for chart continuity
     const days = periodToDays(period);
-    const viewsByDay = fillMissingDates(dailyMap, dailyUniquesMap, days);
+    const viewsByDay = lastNUtcDays(days).map((date) => ({
+      date,
+      views: dailyMap.get(date) ?? 0,
+      uniques: dailyUniquesMap.get(date) ?? 0,
+    }));
 
     const response = createSuccessResponse({
       totalViews,
@@ -256,22 +261,4 @@ export async function GET(request: Request) {
       503,
     );
   }
-}
-
-/**
- * Fill in missing dates with zero values so the chart has continuous data points.
- */
-function fillMissingDates(
-  dailyMap: Map<string, number>,
-  dailyUniquesMap: Map<string, number>,
-  days: number,
-): Array<{ date: string; views: number; uniques: number }> {
-  const result: Array<{ date: string; views: number; uniques: number }> = [];
-
-  for (let i = days - 1; i >= 0; i--) {
-    const date = new Date(Date.now() - i * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-    result.push({ date, views: dailyMap.get(date) ?? 0, uniques: dailyUniquesMap.get(date) ?? 0 });
-  }
-
-  return result;
 }

--- a/app/api/cron/cleanup-r2/route.ts
+++ b/app/api/cron/cleanup-r2/route.ts
@@ -1,7 +1,7 @@
 /**
  * Cloudflare Cron Trigger handler for R2 storage cleanup (HTTP endpoint)
  *
- * Exists for manual triggers; the scheduled handler in worker.ts calls
+ * Exists for manual triggers; the scheduled handler in worker/index.ts calls
  * performR2Cleanup() directly to avoid double Worker invocation billing.
  *
  * Scheduled daily at 2 AM UTC via wrangler.jsonc

--- a/app/api/cron/cleanup/route.ts
+++ b/app/api/cron/cleanup/route.ts
@@ -1,7 +1,7 @@
 /**
  * Cloudflare Cron Trigger handler for database cleanup (HTTP endpoint)
  *
- * Exists for manual triggers; the scheduled handler in worker.ts calls
+ * Exists for manual triggers; the scheduled handler in worker/index.ts calls
  * performCleanup() directly to avoid double Worker invocation billing.
  *
  * Scheduled daily at 3 AM UTC via wrangler.jsonc

--- a/app/api/cron/recover-orphaned/route.ts
+++ b/app/api/cron/recover-orphaned/route.ts
@@ -1,7 +1,7 @@
 /**
  * Cloudflare Cron Trigger handler for orphaned resume recovery (HTTP endpoint)
  *
- * Exists for manual triggers; the scheduled handler in worker.ts calls
+ * Exists for manual triggers; the scheduled handler in worker/index.ts calls
  * recoverOrphanedResumes() directly to avoid double Worker invocation billing.
  *
  * Scheduled every 15 minutes via wrangler.jsonc

--- a/app/api/cron/sync-domains/route.ts
+++ b/app/api/cron/sync-domains/route.ts
@@ -1,7 +1,7 @@
 /**
  * HTTP trigger for disposable email domain sync (manual trigger)
  *
- * Exists for manual triggers; the scheduled handler in worker.ts calls
+ * Exists for manual triggers; the scheduled handler in worker/index.ts calls
  * syncDisposableDomains() directly to avoid double Worker invocation billing.
  *
  * Scheduled daily at 4 AM UTC via wrangler.jsonc

--- a/app/api/site-data/route.ts
+++ b/app/api/site-data/route.ts
@@ -54,8 +54,8 @@ export async function GET() {
           typeof userSiteData.content === "string"
             ? JSON.parse(userSiteData.content)
             : userSiteData.content;
-      } catch {
-        console.error("Failed to parse site_data content");
+      } catch (error) {
+        console.error("Failed to parse site_data content", error);
       }
     }
 

--- a/app/blog/ai-resume-parsing-accuracy/page.tsx
+++ b/app/blog/ai-resume-parsing-accuracy/page.tsx
@@ -2,8 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
 import { StatsGrid } from "@/components/blog/StatsGrid";
-import { getPostBySlug } from "@/lib/blog/posts";
-import { siteConfig } from "@/lib/config/site";
+import { buildBlogPostMetadata, getPostBySlug } from "@/lib/blog/posts";
 
 export const revalidate = 3600;
 
@@ -13,19 +12,7 @@ const relatedPosts = ["pdf-resume-to-website", "resume-writing-tips"]
   .filter(Boolean) as (typeof post)[];
 
 export function generateMetadata(): Metadata {
-  return {
-    title: post.title,
-    description: post.description,
-    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
-    openGraph: {
-      title: `${post.title} | ${siteConfig.fullName}`,
-      description: post.description,
-      siteName: siteConfig.fullName,
-      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
-    },
-    twitter: { card: "summary_large_image" },
-    robots: { index: true, follow: true },
-  };
+  return buildBlogPostMetadata(post);
 }
 
 export default function AiResumeParsingAccuracyPage() {

--- a/app/blog/best-resume-website-builders/page.tsx
+++ b/app/blog/best-resume-website-builders/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
-import { getPostBySlug } from "@/lib/blog/posts";
-import { siteConfig } from "@/lib/config/site";
+import { buildBlogPostMetadata, getPostBySlug } from "@/lib/blog/posts";
 
 export const revalidate = 3600;
 
@@ -12,19 +11,7 @@ const relatedPosts = ["pdf-resume-to-website", "clickfolio-templates-showcase"]
   .filter(Boolean) as (typeof post)[];
 
 export function generateMetadata(): Metadata {
-  return {
-    title: post.title,
-    description: post.description,
-    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
-    openGraph: {
-      title: `${post.title} | ${siteConfig.fullName}`,
-      description: post.description,
-      siteName: siteConfig.fullName,
-      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
-    },
-    twitter: { card: "summary_large_image" },
-    robots: { index: true, follow: true },
-  };
+  return buildBlogPostMetadata(post);
 }
 
 export default function BestResumeWebsiteBuildersPage() {

--- a/app/blog/clickfolio-templates-showcase/page.tsx
+++ b/app/blog/clickfolio-templates-showcase/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
-import { getPostBySlug } from "@/lib/blog/posts";
-import { siteConfig } from "@/lib/config/site";
+import { buildBlogPostMetadata, getPostBySlug } from "@/lib/blog/posts";
 import { getThemeReferralRequirement, THEME_METADATA } from "@/lib/templates/theme-ids";
 
 export const revalidate = 3600;
@@ -13,19 +12,7 @@ const relatedPosts = ["pdf-resume-to-website", "best-resume-website-builders"]
   .filter(Boolean) as (typeof post)[];
 
 export function generateMetadata(): Metadata {
-  return {
-    title: post.title,
-    description: post.description,
-    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
-    openGraph: {
-      title: `${post.title} | ${siteConfig.fullName}`,
-      description: post.description,
-      siteName: siteConfig.fullName,
-      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
-    },
-    twitter: { card: "summary_large_image" },
-    robots: { index: true, follow: true },
-  };
+  return buildBlogPostMetadata(post);
 }
 
 export default function TemplatesShowcasePage() {

--- a/app/blog/cv-website-builder/page.tsx
+++ b/app/blog/cv-website-builder/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
-import { getPostBySlug } from "@/lib/blog/posts";
-import { siteConfig } from "@/lib/config/site";
+import { buildBlogPostMetadata, getPostBySlug } from "@/lib/blog/posts";
 
 export const revalidate = 3600;
 
@@ -12,19 +11,7 @@ const relatedPosts = ["best-resume-website-builders", "how-to-make-a-resume-webs
   .filter(Boolean) as (typeof post)[];
 
 export function generateMetadata(): Metadata {
-  return {
-    title: post.title,
-    description: post.description,
-    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
-    openGraph: {
-      title: `${post.title} | ${siteConfig.fullName}`,
-      description: post.description,
-      siteName: siteConfig.fullName,
-      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
-    },
-    twitter: { card: "summary_large_image" },
-    robots: { index: true, follow: true },
-  };
+  return buildBlogPostMetadata(post);
 }
 
 export default function CvWebsiteBuilderPage() {

--- a/app/blog/how-to-make-a-resume-website/page.tsx
+++ b/app/blog/how-to-make-a-resume-website/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
-import { getPostBySlug } from "@/lib/blog/posts";
-import { siteConfig } from "@/lib/config/site";
+import { buildBlogPostMetadata, getPostBySlug } from "@/lib/blog/posts";
 
 export const revalidate = 3600;
 
@@ -12,19 +11,7 @@ const relatedPosts = ["pdf-resume-to-website", "cv-website-builder"]
   .filter(Boolean) as (typeof post)[];
 
 export function generateMetadata(): Metadata {
-  return {
-    title: post.title,
-    description: post.description,
-    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
-    openGraph: {
-      title: `${post.title} | ${siteConfig.fullName}`,
-      description: post.description,
-      siteName: siteConfig.fullName,
-      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
-    },
-    twitter: { card: "summary_large_image" },
-    robots: { index: true, follow: true },
-  };
+  return buildBlogPostMetadata(post);
 }
 
 export default function HowToMakeAResumeWebsitePage() {

--- a/app/blog/linkedin-to-portfolio/page.tsx
+++ b/app/blog/linkedin-to-portfolio/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
-import { getPostBySlug } from "@/lib/blog/posts";
-import { siteConfig } from "@/lib/config/site";
+import { buildBlogPostMetadata, getPostBySlug } from "@/lib/blog/posts";
 
 export const revalidate = 3600;
 
@@ -12,19 +11,7 @@ const relatedPosts = ["pdf-resume-vs-portfolio", "pdf-resume-to-website"]
   .filter(Boolean) as (typeof post)[];
 
 export function generateMetadata(): Metadata {
-  return {
-    title: post.title,
-    description: post.description,
-    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
-    openGraph: {
-      title: `${post.title} | ${siteConfig.fullName}`,
-      description: post.description,
-      siteName: siteConfig.fullName,
-      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
-    },
-    twitter: { card: "summary_large_image" },
-    robots: { index: true, follow: true },
-  };
+  return buildBlogPostMetadata(post);
 }
 
 export default function LinkedInToPortfolioPage() {

--- a/app/blog/pdf-resume-to-website/page.tsx
+++ b/app/blog/pdf-resume-to-website/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
-import { getPostBySlug } from "@/lib/blog/posts";
-import { siteConfig } from "@/lib/config/site";
+import { buildBlogPostMetadata, getPostBySlug } from "@/lib/blog/posts";
 
 export const revalidate = 3600;
 
@@ -12,19 +11,7 @@ const relatedPosts = ["best-resume-website-builders", "ai-resume-parsing-accurac
   .filter(Boolean) as (typeof post)[];
 
 export function generateMetadata(): Metadata {
-  return {
-    title: post.title,
-    description: post.description,
-    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
-    openGraph: {
-      title: `${post.title} | ${siteConfig.fullName}`,
-      description: post.description,
-      siteName: siteConfig.fullName,
-      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
-    },
-    twitter: { card: "summary_large_image" },
-    robots: { index: true, follow: true },
-  };
+  return buildBlogPostMetadata(post);
 }
 
 export default function PdfResumeToWebsitePage() {

--- a/app/blog/pdf-resume-vs-portfolio/page.tsx
+++ b/app/blog/pdf-resume-vs-portfolio/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
-import { getPostBySlug } from "@/lib/blog/posts";
-import { siteConfig } from "@/lib/config/site";
+import { buildBlogPostMetadata, getPostBySlug } from "@/lib/blog/posts";
 
 export const revalidate = 3600;
 
@@ -12,19 +11,7 @@ const relatedPosts = ["pdf-resume-to-website", "resume-writing-tips"]
   .filter(Boolean) as (typeof post)[];
 
 export function generateMetadata(): Metadata {
-  return {
-    title: post.title,
-    description: post.description,
-    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
-    openGraph: {
-      title: `${post.title} | ${siteConfig.fullName}`,
-      description: post.description,
-      siteName: siteConfig.fullName,
-      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
-    },
-    twitter: { card: "summary_large_image" },
-    robots: { index: true, follow: true },
-  };
+  return buildBlogPostMetadata(post);
 }
 
 export default function PdfResumeVsPortfolioPage() {

--- a/app/blog/personal-resume-website/page.tsx
+++ b/app/blog/personal-resume-website/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
-import { getPostBySlug } from "@/lib/blog/posts";
-import { siteConfig } from "@/lib/config/site";
+import { buildBlogPostMetadata, getPostBySlug } from "@/lib/blog/posts";
 
 export const revalidate = 3600;
 
@@ -12,19 +11,7 @@ const relatedPosts = ["resume-website-vs-linkedin", "pdf-resume-to-website"]
   .filter(Boolean) as (typeof post)[];
 
 export function generateMetadata(): Metadata {
-  return {
-    title: post.title,
-    description: post.description,
-    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
-    openGraph: {
-      title: `${post.title} | ${siteConfig.fullName}`,
-      description: post.description,
-      siteName: siteConfig.fullName,
-      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
-    },
-    twitter: { card: "summary_large_image" },
-    robots: { index: true, follow: true },
-  };
+  return buildBlogPostMetadata(post);
 }
 
 export default function PersonalResumeWebsitePage() {

--- a/app/blog/privacy-at-clickfolio/page.tsx
+++ b/app/blog/privacy-at-clickfolio/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
-import { getPostBySlug } from "@/lib/blog/posts";
+import { buildBlogPostMetadata, getPostBySlug } from "@/lib/blog/posts";
 import { siteConfig } from "@/lib/config/site";
 
 export const revalidate = 3600;
@@ -12,19 +12,7 @@ const relatedPosts = ["pdf-resume-to-website", "best-resume-website-builders"]
   .filter(Boolean) as (typeof post)[];
 
 export function generateMetadata(): Metadata {
-  return {
-    title: post.title,
-    description: post.description,
-    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
-    openGraph: {
-      title: `${post.title} | ${siteConfig.fullName}`,
-      description: post.description,
-      siteName: siteConfig.fullName,
-      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
-    },
-    twitter: { card: "summary_large_image" },
-    robots: { index: true, follow: true },
-  };
+  return buildBlogPostMetadata(post);
 }
 
 export default function PrivacyAtClickfolioPage() {

--- a/app/blog/product-manager-portfolio-website/page.tsx
+++ b/app/blog/product-manager-portfolio-website/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
-import { getPostBySlug } from "@/lib/blog/posts";
-import { siteConfig } from "@/lib/config/site";
+import { buildBlogPostMetadata, getPostBySlug } from "@/lib/blog/posts";
 
 export const revalidate = 3600;
 
@@ -12,19 +11,7 @@ const relatedPosts = ["resume-website-examples", "best-resume-website-builders"]
   .filter(Boolean) as (typeof post)[];
 
 export function generateMetadata(): Metadata {
-  return {
-    title: post.title,
-    description: post.description,
-    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
-    openGraph: {
-      title: `${post.title} | ${siteConfig.fullName}`,
-      description: post.description,
-      siteName: siteConfig.fullName,
-      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
-    },
-    twitter: { card: "summary_large_image" },
-    robots: { index: true, follow: true },
-  };
+  return buildBlogPostMetadata(post);
 }
 
 export default function ProductManagerPortfolioWebsitePage() {

--- a/app/blog/read-cv-alternatives/page.tsx
+++ b/app/blog/read-cv-alternatives/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
-import { getPostBySlug } from "@/lib/blog/posts";
-import { siteConfig } from "@/lib/config/site";
+import { buildBlogPostMetadata, getPostBySlug } from "@/lib/blog/posts";
 
 export const revalidate = 3600;
 
@@ -12,19 +11,7 @@ const relatedPosts = ["best-resume-website-builders", "linkedin-to-portfolio"]
   .filter(Boolean) as (typeof post)[];
 
 export function generateMetadata(): Metadata {
-  return {
-    title: post.title,
-    description: post.description,
-    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
-    openGraph: {
-      title: `${post.title} | ${siteConfig.fullName}`,
-      description: post.description,
-      siteName: siteConfig.fullName,
-      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
-    },
-    twitter: { card: "summary_large_image" },
-    robots: { index: true, follow: true },
-  };
+  return buildBlogPostMetadata(post);
 }
 
 export default function ReadCvAlternativesPage() {

--- a/app/blog/resume-hosting/page.tsx
+++ b/app/blog/resume-hosting/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
-import { getPostBySlug } from "@/lib/blog/posts";
-import { siteConfig } from "@/lib/config/site";
+import { buildBlogPostMetadata, getPostBySlug } from "@/lib/blog/posts";
 
 export const revalidate = 3600;
 
@@ -12,19 +11,7 @@ const relatedPosts = ["pdf-resume-to-website", "personal-resume-website"]
   .filter(Boolean) as (typeof post)[];
 
 export function generateMetadata(): Metadata {
-  return {
-    title: post.title,
-    description: post.description,
-    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
-    openGraph: {
-      title: `${post.title} | ${siteConfig.fullName}`,
-      description: post.description,
-      siteName: siteConfig.fullName,
-      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
-    },
-    twitter: { card: "summary_large_image" },
-    robots: { index: true, follow: true },
-  };
+  return buildBlogPostMetadata(post);
 }
 
 export default function ResumeHostingPage() {

--- a/app/blog/resume-website-examples/page.tsx
+++ b/app/blog/resume-website-examples/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
-import { getPostBySlug } from "@/lib/blog/posts";
-import { siteConfig } from "@/lib/config/site";
+import { buildBlogPostMetadata, getPostBySlug } from "@/lib/blog/posts";
 
 export const revalidate = 3600;
 
@@ -12,19 +11,7 @@ const relatedPosts = ["clickfolio-templates-showcase", "how-to-make-a-resume-web
   .filter(Boolean) as (typeof post)[];
 
 export function generateMetadata(): Metadata {
-  return {
-    title: post.title,
-    description: post.description,
-    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
-    openGraph: {
-      title: `${post.title} | ${siteConfig.fullName}`,
-      description: post.description,
-      siteName: siteConfig.fullName,
-      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
-    },
-    twitter: { card: "summary_large_image" },
-    robots: { index: true, follow: true },
-  };
+  return buildBlogPostMetadata(post);
 }
 
 export default function ResumeWebsiteExamplesPage() {

--- a/app/blog/resume-website-vs-linkedin/page.tsx
+++ b/app/blog/resume-website-vs-linkedin/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
-import { getPostBySlug } from "@/lib/blog/posts";
-import { siteConfig } from "@/lib/config/site";
+import { buildBlogPostMetadata, getPostBySlug } from "@/lib/blog/posts";
 
 export const revalidate = 3600;
 
@@ -12,19 +11,7 @@ const relatedPosts = ["linkedin-to-portfolio", "personal-resume-website"]
   .filter(Boolean) as (typeof post)[];
 
 export function generateMetadata(): Metadata {
-  return {
-    title: post.title,
-    description: post.description,
-    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
-    openGraph: {
-      title: `${post.title} | ${siteConfig.fullName}`,
-      description: post.description,
-      siteName: siteConfig.fullName,
-      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
-    },
-    twitter: { card: "summary_large_image" },
-    robots: { index: true, follow: true },
-  };
+  return buildBlogPostMetadata(post);
 }
 
 export default function ResumeWebsiteVsLinkedinPage() {

--- a/app/blog/resume-writing-tips/page.tsx
+++ b/app/blog/resume-writing-tips/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
-import { getPostBySlug } from "@/lib/blog/posts";
-import { siteConfig } from "@/lib/config/site";
+import { buildBlogPostMetadata, getPostBySlug } from "@/lib/blog/posts";
 
 export const revalidate = 3600;
 
@@ -12,19 +11,7 @@ const relatedPosts = ["ai-resume-parsing-accuracy", "pdf-resume-vs-portfolio"]
   .filter(Boolean) as (typeof post)[];
 
 export function generateMetadata(): Metadata {
-  return {
-    title: post.title,
-    description: post.description,
-    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
-    openGraph: {
-      title: `${post.title} | ${siteConfig.fullName}`,
-      description: post.description,
-      siteName: siteConfig.fullName,
-      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
-    },
-    twitter: { card: "summary_large_image" },
-    robots: { index: true, follow: true },
-  };
+  return buildBlogPostMetadata(post);
 }
 
 export default function ResumeWritingTipsPage() {

--- a/app/blog/student-resume-website/page.tsx
+++ b/app/blog/student-resume-website/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BlogPostLayout } from "@/components/blog/BlogPostLayout";
-import { getPostBySlug } from "@/lib/blog/posts";
-import { siteConfig } from "@/lib/config/site";
+import { buildBlogPostMetadata, getPostBySlug } from "@/lib/blog/posts";
 
 export const revalidate = 3600;
 
@@ -12,19 +11,7 @@ const relatedPosts = ["how-to-make-a-resume-website", "resume-writing-tips"]
   .filter(Boolean) as (typeof post)[];
 
 export function generateMetadata(): Metadata {
-  return {
-    title: post.title,
-    description: post.description,
-    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
-    openGraph: {
-      title: `${post.title} | ${siteConfig.fullName}`,
-      description: post.description,
-      siteName: siteConfig.fullName,
-      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
-    },
-    twitter: { card: "summary_large_image" },
-    robots: { index: true, follow: true },
-  };
+  return buildBlogPostMetadata(post);
 }
 
 export default function StudentResumeWebsitePage() {

--- a/app/for/consultant/page.tsx
+++ b/app/for/consultant/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 import { RoleFaqSection } from "@/components/Faq";
 import { Button } from "@/components/ui/button";
-import { siteConfig } from "@/lib/config/site";
 import {
+  buildRolePageMetadata,
   generatePageBreadcrumbJsonLd,
   generateWebPageJsonLd,
   serializeJsonLd,
@@ -15,22 +15,7 @@ const description =
   "Launch a professional consulting portfolio website from your PDF resume. Privacy controls, custom URL, 10 templates — free forever with no time limits.";
 const path = "/for/consultant";
 
-export const metadata: Metadata = {
-  title,
-  description,
-  alternates: { canonical: `${siteConfig.url}${path}` },
-  openGraph: {
-    title,
-    description,
-    siteName: siteConfig.fullName,
-    images: [{ url: `${siteConfig.url}/api/og/home`, width: 1200, height: 630 }],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title,
-    description,
-  },
-};
+export const metadata: Metadata = buildRolePageMetadata({ title, description, path });
 
 const faqs = [
   {

--- a/app/for/designer/page.tsx
+++ b/app/for/designer/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 import { RoleFaqSection } from "@/components/Faq";
 import { Button } from "@/components/ui/button";
-import { siteConfig } from "@/lib/config/site";
 import {
+  buildRolePageMetadata,
   generatePageBreadcrumbJsonLd,
   generateWebPageJsonLd,
   serializeJsonLd,
@@ -15,22 +15,7 @@ const description =
   "Turn your PDF into a stunning design portfolio website. Showcase your work with 10 beautiful templates — free, no signup required. Custom @handle URL included.";
 const path = "/for/designer";
 
-export const metadata: Metadata = {
-  title,
-  description,
-  alternates: { canonical: `${siteConfig.url}${path}` },
-  openGraph: {
-    title,
-    description,
-    siteName: siteConfig.fullName,
-    images: [{ url: `${siteConfig.url}/api/og/home`, width: 1200, height: 630 }],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title,
-    description,
-  },
-};
+export const metadata: Metadata = buildRolePageMetadata({ title, description, path });
 
 const faqs = [
   {

--- a/app/for/marketer/page.tsx
+++ b/app/for/marketer/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 import { RoleFaqSection } from "@/components/Faq";
 import { Button } from "@/components/ui/button";
-import { siteConfig } from "@/lib/config/site";
 import {
+  buildRolePageMetadata,
   generatePageBreadcrumbJsonLd,
   generateWebPageJsonLd,
   serializeJsonLd,
@@ -15,22 +15,7 @@ const description =
   "Create a standout marketing portfolio website from your PDF resume. Highlight campaign metrics, brands you've worked with, and results — free, with 10 templates.";
 const path = "/for/marketer";
 
-export const metadata: Metadata = {
-  title,
-  description,
-  alternates: { canonical: `${siteConfig.url}${path}` },
-  openGraph: {
-    title,
-    description,
-    siteName: siteConfig.fullName,
-    images: [{ url: `${siteConfig.url}/api/og/home`, width: 1200, height: 630 }],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title,
-    description,
-  },
-};
+export const metadata: Metadata = buildRolePageMetadata({ title, description, path });
 
 const faqs = [
   {

--- a/app/for/product-manager/page.tsx
+++ b/app/for/product-manager/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 import { RoleFaqSection } from "@/components/Faq";
 import { Button } from "@/components/ui/button";
-import { siteConfig } from "@/lib/config/site";
 import {
+  buildRolePageMetadata,
   generatePageBreadcrumbJsonLd,
   generateWebPageJsonLd,
   serializeJsonLd,
@@ -15,22 +15,7 @@ const description =
   "Showcase your product launches, roadmaps, and impact with a free portfolio website. 10 templates, AI-powered parsing from PDF, custom @handle URL.";
 const path = "/for/product-manager";
 
-export const metadata: Metadata = {
-  title,
-  description,
-  alternates: { canonical: `${siteConfig.url}${path}` },
-  openGraph: {
-    title,
-    description,
-    siteName: siteConfig.fullName,
-    images: [{ url: `${siteConfig.url}/api/og/home`, width: 1200, height: 630 }],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title,
-    description,
-  },
-};
+export const metadata: Metadata = buildRolePageMetadata({ title, description, path });
 
 const faqs = [
   {

--- a/app/for/software-engineer/page.tsx
+++ b/app/for/software-engineer/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 import { RoleFaqSection } from "@/components/Faq";
 import { Button } from "@/components/ui/button";
-import { siteConfig } from "@/lib/config/site";
 import {
+  buildRolePageMetadata,
   generatePageBreadcrumbJsonLd,
   generateWebPageJsonLd,
   serializeJsonLd,
@@ -15,22 +15,7 @@ const description =
   "Showcase your code, projects, and experience with a free resume website. 10 templates including DevTerminal, GitHub & LinkedIn integration, and AI-powered PDF parsing.";
 const path = "/for/software-engineer";
 
-export const metadata: Metadata = {
-  title,
-  description,
-  alternates: { canonical: `${siteConfig.url}${path}` },
-  openGraph: {
-    title,
-    description,
-    siteName: siteConfig.fullName,
-    images: [{ url: `${siteConfig.url}/api/og/home`, width: 1200, height: 630 }],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title,
-    description,
-  },
-};
+export const metadata: Metadata = buildRolePageMetadata({ title, description, path });
 
 const faqs = [
   {

--- a/app/for/student/page.tsx
+++ b/app/for/student/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 import { RoleFaqSection } from "@/components/Faq";
 import { Button } from "@/components/ui/button";
-import { siteConfig } from "@/lib/config/site";
 import {
+  buildRolePageMetadata,
   generatePageBreadcrumbJsonLd,
   generateWebPageJsonLd,
   serializeJsonLd,
@@ -15,22 +15,7 @@ const description =
   "Build your first online portfolio as a student — free, with no signup. Upload your PDF resume and get a shareable website with education, projects, and skills sections.";
 const path = "/for/student";
 
-export const metadata: Metadata = {
-  title,
-  description,
-  alternates: { canonical: `${siteConfig.url}${path}` },
-  openGraph: {
-    title,
-    description,
-    siteName: siteConfig.fullName,
-    images: [{ url: `${siteConfig.url}/api/og/home`, width: 1200, height: 630 }],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title,
-    description,
-  },
-};
+export const metadata: Metadata = buildRolePageMetadata({ title, description, path });
 
 const faqs = [
   {

--- a/components/ShareBar.tsx
+++ b/components/ShareBar.tsx
@@ -3,9 +3,8 @@
 import { cva, type VariantProps } from "class-variance-authority";
 import { Check, Copy, Share2, XIcon } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
-import { toast } from "sonner";
 import { type BrandIconVariant, LinkedInIcon, WhatsAppIcon } from "@/components/icons/BrandIcons";
-import { copyToClipboard } from "@/lib/utils/clipboard";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { cn } from "@/lib/utils/cn";
 import {
   generateLinkedInShareUrl,
@@ -118,7 +117,7 @@ interface ShareBarProps extends VariantProps<typeof shareBarVariants> {
  * ```
  */
 export function ShareBar({ url, handle, title, name, variant, className }: ShareBarProps) {
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyToClipboard();
   const [hasWebShare, setHasWebShare] = useState(false);
   const shareText = generateShareText(name);
 
@@ -157,15 +156,11 @@ export function ShareBar({ url, handle, title, name, variant, className }: Share
   }, [shareText, shareUrl]);
 
   const handleCopyLink = useCallback(async () => {
-    try {
-      await copyToClipboard(shareUrl);
-      setCopied(true);
-      toast.success("Link copied!");
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      toast.error("Failed to copy link");
-    }
-  }, [shareUrl]);
+    await copy(shareUrl, {
+      successMessage: "Link copied!",
+      errorMessage: "Failed to copy link",
+    });
+  }, [shareUrl, copy]);
 
   return (
     <fieldset

--- a/components/SharePopover.tsx
+++ b/components/SharePopover.tsx
@@ -3,10 +3,9 @@
 import { cva, type VariantProps } from "class-variance-authority";
 import { Check, Copy, Share2, XIcon } from "lucide-react";
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
-import { toast } from "sonner";
 import { type BrandIconVariant, LinkedInIcon, WhatsAppIcon } from "@/components/icons/BrandIcons";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { siteConfig } from "@/lib/config/site";
-import { copyToClipboard } from "@/lib/utils/clipboard";
 import { cn } from "@/lib/utils/cn";
 import {
   generateLinkedInShareUrl,
@@ -133,7 +132,7 @@ interface SharePopoverProps extends VariantProps<typeof triggerVariants> {
  */
 export function SharePopover({ url, handle, title, name, variant, className }: SharePopoverProps) {
   const [open, setOpen] = useState(false);
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyToClipboard();
   const popoverId = useId();
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -204,16 +203,12 @@ export function SharePopover({ url, handle, title, name, variant, className }: S
   }, [shareText, shareUrl]);
 
   const handleCopyLink = useCallback(async () => {
-    try {
-      await copyToClipboard(shareUrl);
-      setCopied(true);
-      toast.success("Link copied!");
-      setTimeout(() => setCopied(false), 2000);
-      setOpen(false);
-    } catch {
-      toast.error("Failed to copy link");
-    }
-  }, [shareUrl]);
+    await copy(shareUrl, {
+      successMessage: "Link copied!",
+      errorMessage: "Failed to copy link",
+      onSuccess: () => setOpen(false),
+    });
+  }, [shareUrl, copy]);
 
   return (
     <div

--- a/components/YouAreLiveModal.tsx
+++ b/components/YouAreLiveModal.tsx
@@ -2,13 +2,12 @@
 
 import { Check, Copy, ExternalLink, Gift, Rocket, XIcon } from "lucide-react";
 import Link from "next/link";
-import { useCallback, useState } from "react";
-import { toast } from "sonner";
+import { useCallback } from "react";
 import { Confetti } from "@/components/Confetti";
 import { LinkedInIcon, WhatsAppIcon } from "@/components/icons/BrandIcons";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { copyToClipboard } from "@/lib/utils/clipboard";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import {
   generateLinkedInShareUrl,
   generateTwitterShareUrl,
@@ -41,8 +40,8 @@ interface YouAreLiveModalProps {
  * ```
  */
 export function YouAreLiveModal({ open, onOpenChange, handle, url }: YouAreLiveModalProps) {
-  const [copied, setCopied] = useState(false);
-  const [referralCopied, setReferralCopied] = useState(false);
+  const { copied, copy } = useCopyToClipboard();
+  const { copied: referralCopied, copy: copyReferral } = useCopyToClipboard();
 
   const resumeUrl =
     url ||
@@ -58,26 +57,18 @@ export function YouAreLiveModal({ open, onOpenChange, handle, url }: YouAreLiveM
   const shareText = "Just published my professional resume! Check it out:";
 
   const handleCopyLink = useCallback(async () => {
-    try {
-      await copyToClipboard(resumeUrl);
-      setCopied(true);
-      toast.success("Link copied!");
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      toast.error("Failed to copy link");
-    }
-  }, [resumeUrl]);
+    await copy(resumeUrl, {
+      successMessage: "Link copied!",
+      errorMessage: "Failed to copy link",
+    });
+  }, [resumeUrl, copy]);
 
   const handleCopyReferralLink = useCallback(async () => {
-    try {
-      await copyToClipboard(referralUrl);
-      setReferralCopied(true);
-      toast.success("Referral link copied!");
-      setTimeout(() => setReferralCopied(false), 2000);
-    } catch {
-      toast.error("Failed to copy link");
-    }
-  }, [referralUrl]);
+    await copyReferral(referralUrl, {
+      successMessage: "Referral link copied!",
+      errorMessage: "Failed to copy link",
+    });
+  }, [referralUrl, copyReferral]);
 
   const handleTwitterShare = useCallback(() => {
     window.open(generateTwitterShareUrl(shareText, resumeUrl), "_blank", "noopener,noreferrer");

--- a/components/dashboard/AnalyticsCard.tsx
+++ b/components/dashboard/AnalyticsCard.tsx
@@ -6,8 +6,7 @@ import uPlot from "uplot";
 import "uplot/dist/uPlot.min.css";
 import { MilestoneToasts } from "@/components/dashboard/MilestoneToasts";
 import { Skeleton } from "@/components/ui/skeleton";
-
-type Period = "7d" | "30d" | "90d";
+import type { Period } from "@/lib/types/api";
 
 interface AnalyticsStats {
   totalViews: number;

--- a/components/dashboard/CopyLinkButton.tsx
+++ b/components/dashboard/CopyLinkButton.tsx
@@ -1,30 +1,23 @@
 "use client";
 
 import { Check, Link2 } from "lucide-react";
-import { useState } from "react";
-import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { copyToClipboard } from "@/lib/utils/clipboard";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 
 interface CopyLinkButtonProps {
   handle: string;
 }
 
 export function CopyLinkButton({ handle }: CopyLinkButtonProps) {
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyToClipboard();
 
   const handleCopy = async () => {
     const url = `${window.location.origin}/@${handle}`;
 
-    const success = await copyToClipboard(url);
-
-    if (success) {
-      setCopied(true);
-      toast.success("Link copied to clipboard!");
-      setTimeout(() => setCopied(false), 2000);
-    } else {
-      toast.error("Failed to copy link. Please copy manually.");
-    }
+    await copy(url, {
+      successMessage: "Link copied to clipboard!",
+      errorMessage: "Failed to copy link. Please copy manually.",
+    });
   };
 
   return (

--- a/components/dashboard/ReferralStats.tsx
+++ b/components/dashboard/ReferralStats.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { Copy, Gift, MousePointerClick, Share2, Users } from "lucide-react";
-import { useCallback, useState } from "react";
-import { toast } from "sonner";
+import { useCallback } from "react";
 import { Button } from "@/components/ui/button";
-import { copyToClipboard } from "@/lib/utils/clipboard";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 
 interface ReferralStatsProps {
   /** Number of users who signed up via this user's referral link */
@@ -24,7 +23,7 @@ interface ReferralStatsProps {
  * - Prominent copy button with focus ring
  */
 export function ReferralStats({ referralCount, clickCount, referralCode }: ReferralStatsProps) {
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyToClipboard();
 
   const referralUrl =
     typeof window !== "undefined"
@@ -32,15 +31,11 @@ export function ReferralStats({ referralCount, clickCount, referralCode }: Refer
       : `https://clickfolio.me/?ref=${referralCode}`;
 
   const handleCopyLink = useCallback(async () => {
-    try {
-      await copyToClipboard(referralUrl);
-      setCopied(true);
-      toast.success("Referral link copied!");
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      toast.error("Failed to copy link");
-    }
-  }, [referralUrl]);
+    await copy(referralUrl, {
+      successMessage: "Referral link copied!",
+      errorMessage: "Failed to copy link",
+    });
+  }, [referralUrl, copy]);
 
   // Calculate conversion rate
   const conversionRate = clickCount > 0 ? Math.round((referralCount / clickCount) * 100) : 0;

--- a/components/dashboard/ThemeSelector.tsx
+++ b/components/dashboard/ThemeSelector.tsx
@@ -12,6 +12,7 @@ import {
   type ThemeId,
 } from "@/lib/templates/theme-ids";
 import { DYNAMIC_TEMPLATES } from "@/lib/templates/theme-registry.client";
+import type { ApiErrorBody } from "@/lib/types/api";
 import type { ResumeContent } from "@/lib/types/database";
 import { cn } from "@/lib/utils/cn";
 
@@ -26,10 +27,6 @@ interface ThemeSelectorProps {
   referralCount: number;
   /** Whether user has pro status (unlocks all themes) */
   isPro: boolean;
-}
-
-interface ErrorResponse {
-  error?: string;
 }
 
 export function ThemeSelector({
@@ -94,7 +91,7 @@ export function ThemeSelector({
       });
 
       if (!response.ok) {
-        const errorData = (await response.json()) as ErrorResponse;
+        const errorData = (await response.json()) as ApiErrorBody;
         throw new Error(errorData.error || "Failed to update theme");
       }
 

--- a/components/forms/EditResumeFormWrapper.tsx
+++ b/components/forms/EditResumeFormWrapper.tsx
@@ -2,15 +2,12 @@
 
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
+import type { ApiErrorBody } from "@/lib/types/api";
 import type { ResumeContent } from "@/lib/types/database";
 import { EditResumeForm } from "./EditResumeForm";
 
 interface EditResumeFormWrapperProps {
   initialData: ResumeContent;
-}
-
-interface ErrorResponse {
-  error?: string;
 }
 
 export function EditResumeFormWrapper({ initialData }: EditResumeFormWrapperProps) {
@@ -26,7 +23,7 @@ export function EditResumeFormWrapper({ initialData }: EditResumeFormWrapperProp
     });
 
     if (!response.ok) {
-      const error = (await response.json()) as ErrorResponse;
+      const error = (await response.json()) as ApiErrorBody;
       const errorMessage = error.error || "Failed to update resume";
 
       // Display specific error messages to user

--- a/components/forms/HandleForm.tsx
+++ b/components/forms/HandleForm.tsx
@@ -9,10 +9,10 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { siteConfig } from "@/lib/config/site";
 import { type HandleUpdate, handleUpdateSchema } from "@/lib/schemas/profile";
 import type { ApiErrorBody } from "@/lib/types/api";
-import { copyToClipboard } from "@/lib/utils/clipboard";
 
 interface HandleFormProps {
   currentHandle: string;
@@ -21,7 +21,7 @@ interface HandleFormProps {
 
 export function HandleForm({ currentHandle, variant = "default" }: HandleFormProps) {
   const [isSaving, setIsSaving] = useState(false);
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyToClipboard();
   const router = useRouter();
 
   const {
@@ -40,15 +40,10 @@ export function HandleForm({ currentHandle, variant = "default" }: HandleFormPro
   const publicUrl = `${siteConfig.domain}/@${newHandle || currentHandle}`;
 
   const handleCopy = async () => {
-    const success = await copyToClipboard(`https://${publicUrl}`);
-
-    if (success) {
-      setCopied(true);
-      toast.success("URL copied to clipboard");
-      setTimeout(() => setCopied(false), 2000);
-    } else {
-      toast.error("Failed to copy URL");
-    }
+    await copy(`https://${publicUrl}`, {
+      successMessage: "URL copied to clipboard",
+      errorMessage: "Failed to copy URL",
+    });
   };
 
   const onSubmit = async (data: HandleUpdate) => {

--- a/components/forms/HandleForm.tsx
+++ b/components/forms/HandleForm.tsx
@@ -11,16 +11,12 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { siteConfig } from "@/lib/config/site";
 import { type HandleUpdate, handleUpdateSchema } from "@/lib/schemas/profile";
+import type { ApiErrorBody } from "@/lib/types/api";
 import { copyToClipboard } from "@/lib/utils/clipboard";
 
 interface HandleFormProps {
   currentHandle: string;
   variant?: "default" | "compact";
-}
-
-interface ErrorResponse {
-  error?: string;
-  message?: string;
 }
 
 export function HandleForm({ currentHandle, variant = "default" }: HandleFormProps) {
@@ -73,8 +69,8 @@ export function HandleForm({ currentHandle, variant = "default" }: HandleFormPro
       });
 
       if (!response.ok) {
-        const errorData = (await response.json()) as ErrorResponse;
-        throw new Error(errorData.message || "Failed to update handle");
+        const errorData = (await response.json()) as ApiErrorBody;
+        throw new Error(errorData.error || "Failed to update handle");
       }
 
       await response.json();

--- a/components/forms/PrivacySettings.tsx
+++ b/components/forms/PrivacySettings.tsx
@@ -9,14 +9,10 @@ import { toast } from "sonner";
 import { Switch } from "@/components/ui/switch";
 import type { PrivacySettings } from "@/lib/db/schema/auth";
 import { privacySettingsSchema } from "@/lib/schemas/profile";
+import type { ApiErrorBody } from "@/lib/types/api";
 
 interface PrivacySettingsFormProps {
   initialSettings: PrivacySettings;
-}
-
-interface ErrorResponse {
-  error?: string;
-  message?: string;
 }
 
 interface ToggleCardProps {
@@ -102,8 +98,8 @@ export function PrivacySettingsForm({ initialSettings }: PrivacySettingsFormProp
       });
 
       if (!response.ok) {
-        const errorData = (await response.json()) as ErrorResponse;
-        throw new Error(errorData.message || "Failed to update privacy settings");
+        const errorData = (await response.json()) as ApiErrorBody;
+        throw new Error(errorData.error || "Failed to update privacy settings");
       }
 
       toast.success("Privacy settings updated");

--- a/components/wizard/UploadStep.tsx
+++ b/components/wizard/UploadStep.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { clearStoredReferralCode, getStoredReferralCode } from "@/lib/referral";
+import type { ClaimResponse } from "@/lib/types/api";
 import type { ResumeContent } from "@/lib/types/database";
 import { MAX_FILE_SIZE_LABEL, validatePDF } from "@/lib/utils/validation";
 import { waitForResumeCompletion } from "@/lib/utils/wait-for-completion";
@@ -20,12 +21,6 @@ type UploadState = "idle" | "uploading" | "claiming" | "parsing" | "error";
 interface UploadResponse {
   key: string;
   remaining: number;
-  error?: string;
-}
-
-interface ClaimResponse {
-  resume_id: string;
-  cached?: boolean;
   error?: string;
 }
 

--- a/hooks/useCopyToClipboard.ts
+++ b/hooks/useCopyToClipboard.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { copyToClipboard } from "@/lib/utils/clipboard";
+
+interface CopyOptions {
+  /** Toast message shown on a successful copy */
+  successMessage: string;
+  /** Toast message shown when the copy fails */
+  errorMessage: string;
+  /** Optional callback invoked only after a successful copy */
+  onSuccess?: () => void;
+}
+
+interface UseCopyToClipboardReturn {
+  /** True for 2 seconds after a successful copy */
+  copied: boolean;
+  /** Copies text, fires the matching toast, and toggles `copied` on success */
+  copy: (text: string, opts: CopyOptions) => Promise<void>;
+}
+
+/**
+ * Copy-to-clipboard with feedback.
+ *
+ * Calls {@link copyToClipboard} and treats both a thrown error and a falsy
+ * return value as failure. On success it sets `copied` true for 2 seconds,
+ * shows the success toast, and runs the optional `onSuccess` callback. On
+ * failure it shows the error toast.
+ *
+ * @returns `{ copied, copy }`
+ */
+export function useCopyToClipboard(): UseCopyToClipboardReturn {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const copy = useCallback(async (text: string, opts: CopyOptions) => {
+    try {
+      const success = await copyToClipboard(text);
+      if (!success) {
+        toast.error(opts.errorMessage);
+        return;
+      }
+      setCopied(true);
+      toast.success(opts.successMessage);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      timeoutRef.current = setTimeout(() => setCopied(false), 2000);
+      opts.onSuccess?.();
+    } catch {
+      toast.error(opts.errorMessage);
+    }
+  }, []);
+
+  return { copied, copy };
+}

--- a/lib/blog/posts.ts
+++ b/lib/blog/posts.ts
@@ -1,3 +1,6 @@
+import type { Metadata } from "next";
+import { siteConfig } from "@/lib/config/site";
+
 export interface BlogPostFaq {
   q: string;
   a: string;
@@ -463,4 +466,26 @@ export const BLOG_POSTS: BlogPostMeta[] = [
 
 export function getPostBySlug(slug: string): BlogPostMeta | undefined {
   return BLOG_POSTS.find((p) => p.slug === slug);
+}
+
+/**
+ * Builds the Next.js Metadata object for an individual blog post page.
+ * Shared by every app/blog/<slug>/page.tsx so the per-page generateMetadata()
+ * stays a one-line delegation. Output is identical to the previous inline
+ * definition.
+ */
+export function buildBlogPostMetadata(post: BlogPostMeta): Metadata {
+  return {
+    title: post.title,
+    description: post.description,
+    alternates: { canonical: `${siteConfig.url}/blog/${post.slug}` },
+    openGraph: {
+      title: `${post.title} | ${siteConfig.fullName}`,
+      description: post.description,
+      siteName: siteConfig.fullName,
+      images: [{ url: "/api/og/home", width: 1200, height: 630 }],
+    },
+    twitter: { card: "summary_large_image" },
+    robots: { index: true, follow: true },
+  };
 }

--- a/lib/cron/cleanup-r2.ts
+++ b/lib/cron/cleanup-r2.ts
@@ -2,7 +2,7 @@
  * R2 storage cleanup for orphaned temp uploads and durable pending deletions.
  *
  * Called by:
- * - worker.ts scheduled handler (direct invocation, no extra Worker billing)
+ * - worker/index.ts scheduled handler (direct invocation, no extra Worker billing)
  * - /api/cron/cleanup-r2 route handler (manual trigger via HTTP)
  *
  * Deletes:

--- a/lib/cron/cleanup.ts
+++ b/lib/cron/cleanup.ts
@@ -2,7 +2,7 @@
  * Shared cleanup logic for database maintenance.
  *
  * Called by:
- * - worker.ts scheduled handler (direct invocation, no extra Worker billing)
+ * - worker/index.ts scheduled handler (direct invocation, no extra Worker billing)
  * - /api/cron/cleanup route handler (manual trigger via HTTP)
  *
  * Deletes:

--- a/lib/cron/recover-orphaned.ts
+++ b/lib/cron/recover-orphaned.ts
@@ -2,7 +2,7 @@
  * Shared orphaned resume recovery logic.
  *
  * Called by:
- * - worker.ts scheduled handler (direct invocation, no extra Worker billing)
+ * - worker/index.ts scheduled handler (direct invocation, no extra Worker billing)
  * - /api/cron/recover-orphaned route handler (manual trigger via HTTP)
  *
  * Finds resumes stuck in pending_claim status that have valid r2Key and fileHash

--- a/lib/cron/sync-disposable-domains.ts
+++ b/lib/cron/sync-disposable-domains.ts
@@ -2,7 +2,7 @@
  * Sync disposable email domain blocklist from GitHub to KV.
  *
  * Called by:
- * - worker.ts scheduled handler (cron)
+ * - worker/index.ts scheduled handler (cron)
  * - /api/cron/sync-disposable-domains route handler (manual trigger)
  *
  * Source: https://github.com/disposable-email-domains/disposable-email-domains

--- a/lib/queue/types.ts
+++ b/lib/queue/types.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 
 /**
  * Zod schema for resume parse queue messages.
- * Used at system boundaries (worker.ts queue consumer) to validate untrusted input.
+ * Used at system boundaries (worker/index.ts queue consumer) to validate untrusted input.
  *
  * Currently a single-variant discriminated union.
  * Add more message types here when needed — z.discriminatedUnion("type", [...]).

--- a/lib/rate-limit/ip.ts
+++ b/lib/rate-limit/ip.ts
@@ -78,15 +78,10 @@ export async function checkIPRateLimit(ip: string): Promise<IPRateLimitResult> {
   }
 
   // Feature flag bypass for temporary testing (non-production only)
+  // Note: this code only runs when NODE_ENV === "production" (the early return above
+  // handles all non-production cases), so DISABLE_RATE_LIMITS is always ignored here.
   if (process.env.DISABLE_RATE_LIMITS === "true") {
-    if (process.env.NODE_ENV === "production") {
-      console.warn("[SECURITY] DISABLE_RATE_LIMITS ignored in production environment");
-    } else {
-      return {
-        allowed: true,
-        remaining: { hourly: 999, daily: 999 },
-      };
-    }
+    console.warn("[SECURITY] DISABLE_RATE_LIMITS ignored in production environment");
   }
 
   // Skip for localhost IPs or local environment (local preview runs in production mode)
@@ -193,94 +188,13 @@ export async function checkIPRateLimit(ip: string): Promise<IPRateLimitResult> {
  * - DoS via rapid checks
  */
 export async function checkHandleRateLimit(ip: string): Promise<IPRateLimitResult> {
-  // Skip in development
-  if (process.env.NODE_ENV !== "production") {
-    return {
-      allowed: true,
-      remaining: { hourly: HANDLE_CHECK_HOURLY_LIMIT, daily: 1000 },
-    };
-  }
-
-  // Feature flag bypass for temporary testing (non-production only)
-  if (process.env.DISABLE_RATE_LIMITS === "true") {
-    if (process.env.NODE_ENV === "production") {
-      console.warn("[SECURITY] DISABLE_RATE_LIMITS ignored in production environment");
-    } else {
-      return {
-        allowed: true,
-        remaining: { hourly: 999, daily: 999 },
-      };
-    }
-  }
-
-  // Skip for localhost IPs or local environment (local preview runs in production mode)
-  if (LOCAL_IPS.has(ip) || isLocalEnvironment()) {
-    return {
-      allowed: true,
-      remaining: { hourly: HANDLE_CHECK_HOURLY_LIMIT, daily: 1000 },
-    };
-  }
-
-  const ipHash = await hashIP(ip);
-  const now = new Date();
-  const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000).toISOString();
-
-  try {
-    const db = getDb(env.CLICKFOLIO_DB);
-
-    // Count handle checks in the last hour
-    const result = await db
-      .select({ count: sql<number>`COUNT(*)` })
-      .from(uploadRateLimits)
-      .where(
-        and(
-          eq(uploadRateLimits.ipHash, ipHash),
-          eq(uploadRateLimits.actionType, "handle_check"),
-          gte(uploadRateLimits.createdAt, oneHourAgo),
-        ),
-      );
-
-    const count = result[0]?.count ?? 0;
-
-    if (count >= HANDLE_CHECK_HOURLY_LIMIT) {
-      return {
-        allowed: false,
-        remaining: { hourly: 0, daily: 0 },
-        message: "Too many handle checks. Please try again later.",
-      };
-    }
-
-    // Record this check (separate from uploads)
-    try {
-      const expiresAt = new Date(now.getTime() + 60 * 60 * 1000).toISOString(); // 1hr TTL
-      await db.insert(uploadRateLimits).values({
-        id: crypto.randomUUID(),
-        ipHash,
-        actionType: "handle_check",
-        createdAt: now.toISOString(),
-        expiresAt,
-      });
-    } catch (insertError) {
-      console.error("Failed to record handle check rate limit:", insertError);
-      // Continue anyway - fail open for legitimate users
-    }
-
-    return {
-      allowed: true,
-      remaining: {
-        hourly: HANDLE_CHECK_HOURLY_LIMIT - count - 1,
-        daily: 1000,
-      },
-    };
-  } catch (error) {
-    console.error("Handle rate limit check failed:", error);
-
-    // SECURITY: Fail OPEN - same rationale as upload rate limiting
-    return {
-      allowed: true,
-      remaining: { hourly: 1, daily: 1 },
-    };
-  }
+  return checkHourlyActionLimit(ip, {
+    actionType: "handle_check",
+    limit: HANDLE_CHECK_HOURLY_LIMIT,
+    blockedMessage: "Too many handle checks. Please try again later.",
+    insertErrorLabel: "Failed to record handle check rate limit:",
+    checkErrorLabel: "Handle rate limit check failed:",
+  });
 }
 
 /**
@@ -293,31 +207,56 @@ export async function checkHandleRateLimit(ip: string): Promise<IPRateLimitResul
  * - DoS via rapid validation checks
  */
 export async function checkEmailValidateRateLimit(ip: string): Promise<IPRateLimitResult> {
+  return checkHourlyActionLimit(ip, {
+    actionType: "email_validate",
+    limit: EMAIL_VALIDATE_HOURLY_LIMIT,
+    blockedMessage: "Too many email validation checks. Please try again later.",
+    insertErrorLabel: "Failed to record email validate rate limit:",
+    checkErrorLabel: "Email validate rate limit check failed:",
+  });
+}
+
+/**
+ * Shared implementation for single-hourly-limit IP rate limits
+ * (handle availability checks and email validation checks).
+ *
+ * Both actions share the same shape: skip in development, ignore
+ * DISABLE_RATE_LIMITS in production, skip for local IPs/environment,
+ * count actions of `actionType` in the last hour, block at `limit`,
+ * otherwise record the action (1hr TTL) and fail open on any DB error.
+ */
+async function checkHourlyActionLimit(
+  ip: string,
+  options: {
+    actionType: "handle_check" | "email_validate";
+    limit: number;
+    blockedMessage: string;
+    insertErrorLabel: string;
+    checkErrorLabel: string;
+  },
+): Promise<IPRateLimitResult> {
+  const { actionType, limit, blockedMessage, insertErrorLabel, checkErrorLabel } = options;
+
   // Skip in development
   if (process.env.NODE_ENV !== "production") {
     return {
       allowed: true,
-      remaining: { hourly: EMAIL_VALIDATE_HOURLY_LIMIT, daily: 1000 },
+      remaining: { hourly: limit, daily: 1000 },
     };
   }
 
   // Feature flag bypass for temporary testing (non-production only)
+  // Note: this code only runs when NODE_ENV === "production" (the early return above
+  // handles all non-production cases), so DISABLE_RATE_LIMITS is always ignored here.
   if (process.env.DISABLE_RATE_LIMITS === "true") {
-    if (process.env.NODE_ENV === "production") {
-      console.warn("[SECURITY] DISABLE_RATE_LIMITS ignored in production environment");
-    } else {
-      return {
-        allowed: true,
-        remaining: { hourly: 999, daily: 999 },
-      };
-    }
+    console.warn("[SECURITY] DISABLE_RATE_LIMITS ignored in production environment");
   }
 
   // Skip for localhost IPs or local environment (local preview runs in production mode)
   if (LOCAL_IPS.has(ip) || isLocalEnvironment()) {
     return {
       allowed: true,
-      remaining: { hourly: EMAIL_VALIDATE_HOURLY_LIMIT, daily: 1000 },
+      remaining: { hourly: limit, daily: 1000 },
     };
   }
 
@@ -328,52 +267,52 @@ export async function checkEmailValidateRateLimit(ip: string): Promise<IPRateLim
   try {
     const db = getDb(env.CLICKFOLIO_DB);
 
-    // Count email validation checks in the last hour
+    // Count actions of this type in the last hour
     const result = await db
       .select({ count: sql<number>`COUNT(*)` })
       .from(uploadRateLimits)
       .where(
         and(
           eq(uploadRateLimits.ipHash, ipHash),
-          eq(uploadRateLimits.actionType, "email_validate"),
+          eq(uploadRateLimits.actionType, actionType),
           gte(uploadRateLimits.createdAt, oneHourAgo),
         ),
       );
 
     const count = result[0]?.count ?? 0;
 
-    if (count >= EMAIL_VALIDATE_HOURLY_LIMIT) {
+    if (count >= limit) {
       return {
         allowed: false,
         remaining: { hourly: 0, daily: 0 },
-        message: "Too many email validation checks. Please try again later.",
+        message: blockedMessage,
       };
     }
 
-    // Record this check (separate from uploads and handle checks)
+    // Record this check (separate action type, not shared with uploads)
     try {
       const expiresAt = new Date(now.getTime() + 60 * 60 * 1000).toISOString(); // 1hr TTL
       await db.insert(uploadRateLimits).values({
         id: crypto.randomUUID(),
         ipHash,
-        actionType: "email_validate",
+        actionType,
         createdAt: now.toISOString(),
         expiresAt,
       });
     } catch (insertError) {
-      console.error("Failed to record email validate rate limit:", insertError);
+      console.error(insertErrorLabel, insertError);
       // Continue anyway - fail open for legitimate users
     }
 
     return {
       allowed: true,
       remaining: {
-        hourly: EMAIL_VALIDATE_HOURLY_LIMIT - count - 1,
+        hourly: limit - count - 1,
         daily: 1000,
       },
     };
   } catch (error) {
-    console.error("Email validate rate limit check failed:", error);
+    console.error(checkErrorLabel, error);
 
     // SECURITY: Fail OPEN - same rationale as upload rate limiting
     return {

--- a/lib/rate-limit/user.ts
+++ b/lib/rate-limit/user.ts
@@ -120,12 +120,10 @@ export async function enforceRateLimit(
   }
 
   // Feature flag bypass for temporary testing (non-production only)
+  // Note: this code only runs when NODE_ENV === "production" (the early return above
+  // handles all non-production cases), so DISABLE_RATE_LIMITS is always ignored here.
   if (process.env.DISABLE_RATE_LIMITS === "true") {
-    if (process.env.NODE_ENV === "production") {
-      console.warn("[SECURITY] DISABLE_RATE_LIMITS ignored in production environment");
-    } else {
-      return null;
-    }
+    console.warn("[SECURITY] DISABLE_RATE_LIMITS ignored in production environment");
   }
 
   // Skip for local environment (local preview runs in production mode)

--- a/lib/schemas/profile.ts
+++ b/lib/schemas/profile.ts
@@ -89,7 +89,9 @@ export const roleUpdateSchema = z.object({
 
 /**
  * Wizard completion request schema.
- * Imported from lib/templates to avoid duplicating theme ID validation.
+ * Theme IDs are injected via the `themeIds` parameter rather than imported here,
+ * keeping lib/templates as the single source of truth for valid theme IDs
+ * (the caller passes THEME_IDS from lib/templates).
  */
 export function buildWizardCompleteSchema(themeIds: readonly [string, ...string[]]) {
   return z.object({

--- a/lib/seo/json-ld.ts
+++ b/lib/seo/json-ld.ts
@@ -4,6 +4,7 @@
  * to enable rich snippets in Google/Bing search results.
  */
 
+import type { Metadata } from "next";
 import { FAQ_ITEMS } from "@/lib/config/faq";
 import { siteConfig } from "@/lib/config/site";
 import type { ResumeContent } from "@/lib/types/database";
@@ -569,6 +570,35 @@ export function generateWebPageJsonLd(
     page.dateModified = dateModified;
   }
   return page;
+}
+
+/**
+ * Builds the Next.js Metadata object for a /for/<role> profession landing page.
+ * Shared by every app/for/<role>/page.tsx so the per-page `export const metadata`
+ * stays a one-line call. Output is identical to the previous inline definition.
+ */
+export function buildRolePageMetadata(params: {
+  title: string;
+  description: string;
+  path: string;
+}): Metadata {
+  const { title, description, path } = params;
+  return {
+    title,
+    description,
+    alternates: { canonical: `${siteConfig.url}${path}` },
+    openGraph: {
+      title,
+      description,
+      siteName: siteConfig.fullName,
+      images: [{ url: `${siteConfig.url}/api/og/home`, width: 1200, height: 630 }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
 }
 
 /**

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared client-facing types for talking to the app's JSON API routes.
+ *
+ * Error bodies are produced by `createErrorResponse` in
+ * `lib/utils/security-headers.ts`, which always emits `{ error, code, details }`
+ * (never `message`). Clients should read `error` for the user-facing string.
+ */
+
+/** Error body returned by `createErrorResponse` for any non-OK API response. */
+export interface ApiErrorBody {
+  error?: string;
+  code?: string;
+  details?: unknown;
+}
+
+/** Response body for POST /api/resume/claim. */
+export interface ClaimResponse {
+  resume_id: string;
+  cached?: boolean;
+  error?: string;
+}
+
+/** Analytics time window accepted by the analytics API routes. */
+export type Period = "7d" | "30d" | "90d";

--- a/lib/utils/date-axis.ts
+++ b/lib/utils/date-axis.ts
@@ -3,9 +3,9 @@
  */
 
 /**
- * Returns the last `days` UTC calendar days as YYYY-MM-DD strings, in ascending
- * order ending today (UTC). Used to build a continuous descending-built date
- * axis for analytics responses (callers map each date to their own row shape).
+ * Returns the last `days` UTC calendar days as YYYY-MM-DD strings, oldest first
+ * and ending today (UTC). Used to build a gap-free date axis for analytics
+ * responses (callers map each date to their own row shape).
  *
  * Anchored on Date.now() so it tracks the current wall clock per request.
  *

--- a/lib/utils/date-axis.ts
+++ b/lib/utils/date-axis.ts
@@ -1,0 +1,21 @@
+/**
+ * Date-axis helpers for analytics charts.
+ */
+
+/**
+ * Returns the last `days` UTC calendar days as YYYY-MM-DD strings, in ascending
+ * order ending today (UTC). Used to build a continuous descending-built date
+ * axis for analytics responses (callers map each date to their own row shape).
+ *
+ * Anchored on Date.now() so it tracks the current wall clock per request.
+ *
+ * @param days - Number of trailing days to produce
+ * @returns Array of YYYY-MM-DD strings, oldest first, length === days
+ */
+export function lastNUtcDays(days: number): string[] {
+  const result: string[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    result.push(new Date(Date.now() - i * 24 * 60 * 60 * 1000).toISOString().slice(0, 10));
+  }
+  return result;
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -58,7 +58,9 @@ export default {
   async fetch(request: Request, env: CloudflareEnv, _ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
 
-    // Intercept WebSocket upgrade requests for resume status
+    // Manually intercept WebSocket upgrade requests for resume status.
+    // TODO(vinext): Remove once vinext handles WebSocket upgrades upstream;
+    // this auth interception exists only because vinext does not route them.
     if (
       url.pathname === "/ws/resume-status" &&
       request.headers.get("Upgrade")?.toLowerCase() === "websocket"
@@ -90,7 +92,6 @@ export default {
         return new Response("Unauthorized: Invalid session", { status: 401 });
       }
 
-      // TODO(vinext): Remove once vinext fixes this upstream
       const userId = session.user.id;
 
       // Verify resume ownership via D1 query


### PR DESCRIPTION
## Summary

Disciplined repo-wide cleanup via the `/code-cleanup` skill. Phase 1 auto-applied the SAFE tier; Phase 2 (this PR's bulk) implements the surfaced REVIEW queue after explicit approval. **Net −300 lines.** Every change validated after each commit (`tsc --noEmit`, `vp lint`, full test suite **1960 passed / 9 skipped**, `vp build`), and the whole branch passed an independent adversarial review (5 cluster skeptics → 0 blockers, behavior-preservation confirmed).

The one **behavior change** is an explicit bug fix (see below); everything else is behavior-preserving refactor/cleanup.

## Commits (one per concern)

- **`chore: code cleanup phase 1 (SAFE)`** — fix stale doc path references (comment-only): `worker.ts → worker/index.ts` in 9 docstrings (renamed in vinext migration), `lib/utils/handle-validation.ts → lib/rate-limit/handle-validation.ts` (moved in #122).
- **`refactor(rate-limit): drop unreachable bypass branch, dedupe hourly checks`** — collapse 4 unreachable `DISABLE_RATE_LIMITS` dev-bypass else-branches (dead behind a prior `NODE_ENV !== "production"` return; the `[SECURITY]` warn tests pin is kept); merge the two near-identical hourly-limit functions into a parameterized helper. `checkIPRateLimit` left standalone. No public API or fail-open/closed change.
- **`fix(forms): surface real API error messages; consolidate shared API types`** — 🐛 **bug fix:** `HandleForm`/`PrivacySettings` read `errorData.message`, but the server only ever emits `{ error, code, details }` — so the toast *always* showed the generic fallback. Now read `errorData.error` (same fallback). Also consolidates `ApiErrorBody`/`ClaimResponse`/`Period` into `lib/types/api.ts`. Two test fixtures that mocked the fabricated `{ message }` shape are corrected to `{ error }` (assertions unchanged → now verify the fix).
- **`refactor(analytics): extract shared lastNUtcDays date-axis helper`** — three routes' duplicated `fillMissingDates` → `lib/utils/date-axis.ts`. Byte-identical output (admin/analytics keeps its row-keyed map so session-only dates still resolve to `unique:0`).
- **`refactor(seo): extract shared metadata builders for blog and /for pages`** — 17 blog pages + 6 `/for` pages delegate to `buildBlogPostMetadata` / `buildRolePageMetadata`. Emitted `Metadata` identical per page.
- **`refactor(ui): extract useCopyToClipboard hook`** — 6 components' copy-with-feedback pattern → `hooks/useCopyToClipboard.ts`. Same toasts, same 2s reset, same call args; popover-close-on-success and the modal's two independent states preserved; adds unmount cleanup.
- **`chore: log parse error for parity; fix two stale/misplaced comments`** — site-data parse-catch logs the error (parity, no PII); reword a wrong docstring; relocate an orphaned `TODO(vinext)`.
- **`docs: clarify lastNUtcDays ordering wording`** — review nit.

## Deliberately NOT done (out of REVIEW scope / declined)

- `parseJsonBody` extraction across 7 routes — would require rewriting test mocks that drive 413/size behavior via `validateRequestSize` isolation (test-weakening), so dropped.
- A `<JsonLd>` component (~25 sites) — low-value churn over an idiomatic, security-reviewed snippet.
- The `theme-access.ts` always-false pluralization branch — left as correct forward-compatible defensive code.

## Validation

`tsc --noEmit` ✅ · `vp lint` ✅ · `vp test run` ✅ 1960 passed / 9 skipped · `vp build` ✅. Independent adversarial review: 0 blockers, 0 warnings.

## Pre-existing (not addressed here)

- `worker/index.ts` zod `.flatten()` deprecation hint (unrelated; line shifted by a comment edit).
