### PR TITLE
fix: drop unused theme-registry re-exports (knip)

### DIFF
--- a/lib/templates/theme-registry.ts
+++ b/lib/templates/theme-registry.ts
@@ -8,9 +8,6 @@
 import type { TemplateProps } from "@/lib/types/template";
 import { DEFAULT_THEME, isValidThemeId, type ThemeId } from "./theme-ids";
 
-export type { ThemeId } from "./theme-ids";
-export { isThemeUnlocked, THEME_IDS, THEME_METADATA } from "./theme-ids";
-
 /**
  * Lazy loaders — each returns a dynamic import() promise.
  * Used by server components via the async getTemplate().


### PR DESCRIPTION
## Summary
- Remove unused re-exports from `lib/templates/theme-registry.ts`
- Unblocks main CI after #216 (knip 6.x flags them)

Local hook OOM'd on oxlint; CI is the verifier.

## Test plan
- [x] `pnpm run type-check` green
- [ ] CI Build & Verify / knip green